### PR TITLE
Remove leading headers from Math 211 TeX exams

### DIFF
--- a/source/ch-2024-fall-exams/Math211Fa24-FinalExam-PracticeA.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-FinalExam-PracticeA.tex
@@ -1,0 +1,329 @@
+\documentclass[addpoints,12pt]{exam}
+\newcommand{\ds}{\displaystyle}
+\usepackage[margin=0.8in]{geometry}
+\usepackage{subcaption}
+\usepackage{tikz}
+\usepackage{amssymb,amsmath,graphicx,wrapfig,verbatim,wasysym, enumitem,psfragx,color}
+\usepackage{multicol}
+
+\usepackage{tikz}
+\usepackage{graphicx,ctable,booktabs}
+
+%\usepackage{fancyhdr}
+%\setlength{\headheight}{13.6pt}
+%\pagestyle{fancy}
+%\lhead{Math 222}
+%\chead{ Midterm 1 }
+%\rhead{Spring 2022}
+
+\def\FillInBlank{\rule{3truein} {.01truein}}
+
+
+% Choose one option (bubbles)
+\newcommand{\chooseone}{{\Large$\Circle$\ \ }}
+
+
+\newcommand{\myleft}{\makebox[.4\textwidth]{First Name:\enspace\hrulefill}}
+\newcommand{\myright}{\makebox[.4\textwidth]{Last Name:\enspace\hrulefill}}
+\header{\oddeven{\myleft}{}}
+    {}
+    {\oddeven{\myright}{}}
+
+\footrule
+
+\footer{Math 211}
+     {Final Exam - Practice Exam}
+     {Page \thepage\ of \numpages}
+
+\begin{document}
+
+\begin{questions}
+
+
+\question Are each of the following true or false statements? Fill in the bubble next to the
+correct answer. Justification is not necessary.
+
+\begin{parts}
+
+
+\part[2] If $f(x,y)=\dfrac{\ln(2x)}{y}$, the domain of $f(x,y)$ is $\{(x,y)|x>0, y>0\}.$
+
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+
+
+
+\part[2] The improper integral $\ds\int_{9}^\infty \dfrac{4}{x^2}dx$ is divergent.
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+
+
+
+\part[2] The improper integral $\ds\int_{9}^\infty \dfrac{4}{\sqrt{x}}dx$ is divergent.
+
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+\part[2] An equation for the tangent line of $f(x)=2x^3+4x$ at $x=-1$ is $y=10x+4$.
+
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+
+\part[2] The area between the curves $y=\frac{x^2}{4}-2$ and $y=\frac{x}{2}$ (see graph below)
+is given by the integral $\ds\int_{-2}^4\left(\frac{x^2}{4}-2-\frac{x}{2}\right)dx$.
+
+\begin{itemize}[label={}]
+\item \chooseone True
+
+\item \chooseone False
+\end{itemize}
+
+\begin{tikzpicture}[scale=.7]
+\draw[gray!60] (-5, -3) grid[step=1] (5, 3);
+\draw[<->,thick,black] (-5.5,0)--(5.5,0) node[right]{$x$};
+\draw[<->, thick,black] (0,-3.5)--(0,4) node[above]{$y$};
+\foreach \x in {-5,-4,...,5}
+\draw[thick] (\x,-.1) --(\x,.1);
+\foreach \y in {-3,-2,...,3}
+\draw[thick] (-.1,\y) --(.1,\y);
+\draw[domain=-4.5:4.5,samples=100, thick,<->] plot ({\x},{\x*\x/4-2});
+\draw[domain=-4.5:4.6,samples=100,thick,<->] plot ({\x},{\x/2});
+\end{tikzpicture}
+
+
+
+
+\vfill
+
+
+\end{parts}
+
+\newpage
+
+
+\newpage
+
+
+\question
+Calculate the derivative of each function. You do not need to simplify your answer.
+
+
+\begin{parts}
+
+\part[4] $f(x)=\ds\frac{1}{2x^4}-\sqrt{3x}+e^2$
+
+
+\vfill
+
+
+\part[4] $\ds g(x)=e^{x^2+2x}$
+
+\vfill
+
+
+\part[5] $F(x)=(3x^4+e^x)^8$
+
+\vfill
+
+\part[5] $r(x)=(4x^3+7x)\ln(x)$
+
+\vfill
+
+
+
+
+\end{parts}
+
+\newpage
+
+%Revenue optimization
+
+\question
+Calculate each integral. You do not need to simplify your answer. Show all work.
+\begin{parts}
+
+\part[5] $\ds \int \left(10x^4+\dfrac{8}{x}+\dfrac{3}{x^2}\right)dx $
+
+\vspace{1.75in}
+
+\part[6] $\ds \int \sqrt{x}(4x^3+7) dx $
+
+\vfill
+
+\part[6] $\ds \int \left( 4e^{2x} + \dfrac{1}{2} \right)dx $
+
+\vfill
+
+\end{parts}
+​
+
+\newpage
+
+\question[9] A company's marginal cost function is $MC(x)=2e^{-x}$, where $x$ is the number of
+units. Find the total cost of producing the first hundred units ($x=0$ to $x=100$). Show all work.
+You do not need to simplify your final numerical answer.
+​
+
+\newpage
+
+\question[7] Find the average value of $f(x)=x-3\sqrt{x}$ on the interval $[1,4]$.
+
+
+\newpage
+
+\question A parking lot owner has $450$ parking spots to rent out. If the owner charges $x$
+dollars per parking spot, the number of spots that
+will be rented out is given by the function
+
+$$f(x)= 450-10x.$$
+
+\begin{parts}
+
+\part[2] Find $R(x)$, where $R(x)$ is the revenue the parking lot owner receives as a function of
+$x$.
+
+\vspace{3in}
+
+\part[5] What price should the parking lot owner charge to maximize revenue? Justify your
+solution is optimal. Show all work.
+
+\end{parts}
+
+\newpage
+
+
+
+
+\question
+Reminder: If $d(x)$ is the demand function, and $s(x)$ is the supply function,
+
+
+
+
+$(\text{Consumers' surplus for $d(x)$ at demand level $A$})=\ds\int_0^A[d(x)-B]dx$ (where
+$B=d(A)$)
+
+
+$(\text{Producers' surplus for $s(x)$ at demand level $A$})=\ds\int_0^A[B-s(x)]dx$ (where
+$B=s(A)$)
+
+\bigskip
+
+Suppose a product has demand function $d(x)=300-\frac{1}{2}x^2$ and supply function
+$s(x)=\frac{1}{4}x^2$. %%flip the 1/2 and the 1/4 on the makeup.
+\begin{parts}
+\part[5] Find the \textbf{producers' surplus} at demand level $A=10$. Show all work. Evaluate
+the integral, but you do not need to simplify your final numerical answer.
+\vfill
+\part[3] Find the \textbf{market demand} (the positive value of $x$ where supply and demand
+are equal). Show all work. Simplify your final answer.
+
+\vspace{3in}
+
+
+
+
+\end{parts}
+\newpage
+
+\question For $f(x,y)=x^3+y^2-12x+6y$:
+
+\begin{parts}
+
+\part[2] Find the partial derivative $f_x$.
+
+\vspace{2in}
+
+\part[2] Find the partial derivative $f_y$.
+
+\vspace{2in}
+
+\part[4] Find all the critical points of $f(x,y)$. Write each in the form $(x,y)$. Show all work.
+
+\end{parts}
+
+\newpage
+
+
+
+
+\newpage
+\question
+Use the graph of $y=f'(x)$ to answer the following. {Briefly justify your answers.}
+
+\begin{tikzpicture}[scale=1]
+\draw[gray!60] (-6, -4) grid[step=1] (6, 6);
+\draw[<->,thick,black] (-7,0)--(7,0) node[right]{$x$};
+\draw[<->, thick,black] (0,-4.5)--(0,6.5) node[above]{$y$};
+\foreach \x in {-6,-5,...,6}
+\draw[thick] (\x,-.1) --(\x,.1) node[below] { \x};
+\foreach \y in {-4,-3,...,6}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] { \y};
+\draw[domain=-4.3:4.6,samples=100, thick,<->,color=blue] plot ({\x},{-(\x+1)/6*(\x+3)*(\x-4)});
+\node[color=blue] at (2,5.5) {$y=f'(x)$};
+\end{tikzpicture}
+
+Again, \textbf{this is the graph of the derivative of $f(x)$.}
+\begin{parts}
+​       \part[2] On which interval(s) is $f(x)$ increasing? Briefly justify your answer.
+ \vfill
+
+​         \part[2] Is $f(x)$ concave up or concave down at $x=-4$? Briefly justify your answer.
+ \vfill
+
+​       \part[2] What is $\displaystyle \lim_{h\to0}\frac{f(3+h)-f(3)}{h}$? Briefly justify your
+answer.
+ \vfill
+
+ \end{parts}
+
+
+\newpage
+
+\question For the function $f(x,y)=x^3-y^3-9xy+4$:
+\begin{parts}
+\part[5] Compute $f_{xx}, f_{yy},$ and $f_{xy}$. Show all work.
+\vspace{3in}
+
+
+\part[5] The critical points of $f(x,y)$ are $(0,0)$ and $(-3,3)$. Determine, using the $D$-test, if
+each point corresponds to a relative maximum, relative minimum, or saddle point. Show all
+work.
+
+Reminder: $D=f_{xx}(a,b)f_{yy}(a,b)-[f_{xy}(a,b)]^2$
+
+\end{parts}
+\vspace{0.25in}
+
+\newpage
+
+
+
+
+\newpage
+
+
+
+
+\end{questions}
+
+\end{document}

--- a/source/ch-2024-fall-exams/Math211Fa24-FinalExam-PracticeB.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-FinalExam-PracticeB.tex
@@ -1,0 +1,312 @@
+\documentclass[addpoints,12pt]{exam}
+\newcommand{\ds}{\displaystyle}
+\usepackage[margin=0.8in]{geometry}
+\usepackage{subcaption}
+\usepackage{tikz}
+\usepackage{amssymb,amsmath,graphicx,wrapfig,verbatim,wasysym, enumitem,psfragx,color}
+\usepackage{multicol}
+
+
+\usepackage{tikz}
+\usepackage{graphicx,ctable,booktabs}
+
+\usepackage{pgfplots}
+
+
+\pgfplotsset{compat=1.10}
+\usepgfplotslibrary{fillbetween}
+\usetikzlibrary{patterns}
+\pgfdeclarelayer{background}% determine background layer
+\pgfsetlayers{background,main}% order of layers
+
+%\usepackage{fancyhdr}
+%\setlength{\headheight}{13.6pt}
+%\pagestyle{fancy}
+%\lhead{Math 222}
+%\chead{ Midterm 1 }
+%\rhead{Spring 2022}
+
+\def\FillInBlank{\rule{3truein} {.01truein}}
+
+
+
+
+% Choose one option (bubbles)
+\newcommand{\chooseone}{{\Large$\Circle$\ \ }}
+% Choose multiple options (squares)
+
+\newcommand{\choosemany}{{\Large$\Square$\ \ }}
+
+
+\newcommand{\myleft}{\makebox[.4\textwidth]{First Name:\enspace\hrulefill}}
+\newcommand{\myright}{\makebox[.4\textwidth]{Last Name:\enspace\hrulefill}}
+\header{\oddeven{\myleft}{}}
+    {}
+    {\oddeven{\myright}{}}
+
+\footrule
+
+\footer{Math 211}
+     {Final Exam - Practice Exam}
+     {Page \thepage\ of \numpages}
+
+\begin{document}
+
+\begin{questions}
+
+
+\question Clearly mark the correct answer(s) for each of the following by completely filling in the
+appropriate bubble. \textbf{No justification is needed.}
+
+\begin{parts}
+
+
+\part[2] \textbf{(Multiple Choice-Choose one)} The reproduction function for salmon in a fishery
+is
+
+$f(p)=-\frac{1}{10}p^2+13p$, where $p$ and $f(p)$ are in the thousands. The maximum
+sustainable yield is which of the following?
+
+\begin{itemize}[label={}]
+\item \chooseone $60$ thousand
+\item \chooseone $360$ thousand
+\item \chooseone $420$ thousand
+\item \chooseone None of the above.
+\end{itemize}
+
+\vfill
+
+\part[2]\textbf{(Multiple Choice-Choose one)} If $f(x,y)$ has a critical point where $f_{xx}$ and
+$f_{yy}$ are both positive, then...
+\begin{itemize}[label={}]
+\item \chooseone $f$ must have a relative minimum at that point.
+\item \chooseone $f$ must have a relative maximum at that point.
+\item \chooseone $f$ must have saddle point at that point.
+\item \chooseone There is not enough information to classify the critical point.
+\end{itemize}
+
+\vfill
+
+
+
+
+\part[2] \textbf{(True/False)} If $C(x,y)$ is the cost function for a soda factory for $x$ units of
+Coca-Cola and $y$ units of Sprite, $C_x(x,y)$ is the marginal cost function for Sprite when the
+production of Coca-Cola is held constant.
+
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+\part[2] \textbf{(True/False)} $\ds\int_0^\infty \frac{1}{10000}dx$ converges.
+
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+
+\part[2] \textbf{(Multiple Choice-Choose one)} Suppose a study indicates that the distribution of
+income for lawyers is given by the Lorenz curve $L(x)=x^2$. Suppose the Gini index for doctors
+is $0.5$. Which profession has the more equal distribution of income?
+
+\begin{itemize}[label={}]
+\item \chooseone Lawyers
+\item \chooseone Doctors
+\item \chooseone They are the same.
+\end{itemize}
+
+\vfill
+
+
+\end{parts}
+
+\newpage
+
+
+\newpage
+
+
+\newpage
+
+
+
+
+\question The demand function $d(x)$ and supply function $s(x)$ for a particular commodity are
+given as:
+$$d(x)=131-\frac{1}{3}x^2, \; \; s(x)=50+\frac{2}{3}x^2$$
+\begin{parts}
+\part[4] Find the consumers' surplus at demand level $A=3$. You do not need to simplify your
+final numerical answer.\vfill
+\part[3] Find the market demand (the positive value of $x$ at which the demand function
+intersects the supply function).\vfill
+\part[4] Find the producers' surplus at market demand. You do not need to simplify your final
+numerical answer.\vfill
+
+
+
+
+\end{parts}
+
+
+\newpage
+
+\newpage
+\question[8] Evaluate the following improper integral or show that it is divergent.
+
+$\ds \int_0^\infty \dfrac{e^{2x}-e^{4x}}{e^{6x}}dx$
+
+
+\newpage
+
+\question
+Calculate the derivative of each function. You do not need to simplify your answer.
+
+
+\begin{parts}
+
+\part[5] $f(x)=\dfrac{1}{x}+4\sqrt{x}-\sqrt{5}$
+
+
+\vfill
+
+
+\part[5] $\ds g(x)=\ln(3x-x^2)$
+
+
+\vfill
+
+
+\part[5] $F(x)=e^x(x^3+3x)$
+
+\vfill
+
+\part[5] $r(x)=\sqrt[3]{x^3+1}$
+
+\vfill
+
+
+
+
+\end{parts}
+
+\newpage
+
+%Revenue optimization
+
+\question
+
+Calculate each integral. You do not need to simplify your answer. Show all work.
+\begin{parts}
+
+\part[5] $\ds \int x^2(1-4x^3)dx $
+
+\vspace{1.75in}
+
+\part[5] $\ds \int \frac{1-\sqrt{x}}{\sqrt{x}} dx $
+
+\vfill
+
+\part[5] $\ds \int \left(\dfrac{3}{2x}+e^{-x}\right)dx $
+
+\vfill
+
+\end{parts}
+​
+
+\newpage
+
+
+
+
+\question[8] The promoters of a state fair estimate that $t$ hours after the gates open at
+9:00am, visitors will be entering the fair at the rate of $N'(t)=16-t^2$ hundred people per hour.
+Find the total number of people who will enter the fair between 11:00am and 2:00pm. You do not
+need to simplify the final numerical answer, but provide units.
+​
+
+\newpage
+
+\question[8] Set up and evaluate the integral to compute the shaded area (see below) bounded
+by the graphs $y=3-2x-x^2$ and $y=x-1$. You do not need to simplify your final numerical
+answer.
+
+\begin{tikzpicture}[scale=1]
+\begin{axis}[axis on top=true,axis lines=middle,axis line style = thick,
+        xlabel=$x$,
+        ylabel=$y$,
+        enlargelimits,
+        ytick=\empty,
+        xtick=\empty
+        ]
+
+\addplot[name path=F,black, very thick,<->,domain={-4.5:2}] {x-1};
+
+\addplot[name path=G,black,very thick,<->, domain={-4.5:2}] {3-2*x-x^2};
+
+
+\addplot[color=gray!30]fill between[of=G and F, soft clip={domain=-4:1}];
+
+
+%\node at (axis cs:2,2.45){};
+\end{axis}
+\end{tikzpicture}
+
+\newpage
+
+
+
+
+\newpage
+
+\question For the function $f(x,y)=x^2+2y^2-x^2y$:
+\begin{parts}
+\part[5] Compute $f_{xx}, f_{yy},$ and $f_{xy}$. Show all work.
+\vspace{3in}
+
+
+\part[5] The critical points of $f(x,y)$ are $(0,0), (2,1)$, and $(-2,1)$. Determine, using the
+$D$-test, if each point corresponds to a relative maximum, relative minimum, or saddle point.
+Show all work.
+
+
+\end{parts}
+\vspace{0.25in}
+
+\newpage
+
+
+\question Given the following information about two functions, $g(x)$ and $f(x)$:
+\begin{itemize}
+​       \item[] $f(3)=4$ \quad $f'(3)=-7$
+​       \item[] $g(3)=2$ \quad $g'(3)=5$
+​       \item[] $f(6)=8$ \quad $f'(6)=3$
+\item[] $g(6)=9$\quad $g'(6)=10$
+​
+\end{itemize}
+Compute each of the following. Simplify your answers.
+\begin{parts}
+
+​      \part[2] $h'(3)$ if $h(x)=f(x)g(x)$.\vfill
+​      \part[2] $h'(6)$ if $h(x)=\dfrac{3f(x)}{4}$.\vfill
+​      \part[2] $\displaystyle \lim_{h\to 0}\dfrac{f(h+3)-f(3)}{h}$.\vfill
+     \part[2] The average value of $g'(x)$ on $[3,6]$.\vfill
+​      \part[2] The relative rate of change of $g(x)$ at $x=3$.\vfill
+\end{parts}
+
+
+
+
+\newpage
+
+
+
+
+\end{questions}
+
+\end{document}

--- a/source/ch-2024-fall-exams/Math211Fa24-FinalExam.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-FinalExam.tex
@@ -1,0 +1,358 @@
+\documentclass[addpoints,12pt]{exam}
+\newcommand{\ds}{\displaystyle}
+\usepackage[margin=0.8in]{geometry}
+\usepackage{subcaption}
+\usepackage{tikz}
+\usepackage{amssymb,amsmath,graphicx,wrapfig,verbatim,wasysym, enumitem,psfragx,color}
+\usepackage{multicol}
+
+
+\usepackage{pgf,tikz,pgfplots}
+\usepackage{stmaryrd}
+\usetikzlibrary{arrows, shapes.geometric, matrix, turtle, plotmarks}
+
+
+
+
+\pgfplotsset{compat=1.10}
+\usepgfplotslibrary{fillbetween}
+\usetikzlibrary{patterns}
+
+\pgfdeclarelayer{background}% determine background layer
+\pgfsetlayers{background,main}% order of layers
+
+%\usepackage{fancyhdr}
+%\setlength{\headheight}{13.6pt}
+%\pagestyle{fancy}
+%\lhead{Math 222}
+%\chead{ Midterm 1 }
+%\rhead{Spring 2022}
+
+\def\FillInBlank{\rule{3truein} {.01truein}}
+
+
+
+
+% Choose one option (bubbles)
+\newcommand{\chooseone}{{\Large$\Circle$\ \ }}
+% Choose multiple options (squares)
+\newcommand{\choosemany}{{\Large$\Square$\ \ }}
+
+
+\newcommand{\myleft}{\makebox[.4\textwidth]{First Name:\enspace\hrulefill}}
+\newcommand{\myright}{\makebox[.4\textwidth]{Last Name:\enspace\hrulefill}}
+\header{\oddeven{\myleft}{}}
+    {}
+    {\oddeven{\myright}{}}
+
+\footrule
+
+\footer{Math 211}
+     {Final Exam - Fall 2024}
+     {Page \thepage\ of \numpages}
+
+\begin{document}
+
+\begin{questions}
+
+
+\newpage
+
+
+
+
+\question Find each derivative. You do not need to simplify your answers.
+
+\begin{parts}
+
+
+\part[4] Find $r'(t)$ if $r(t)=\ln(t^4-2t)$
+
+\vfill
+
+
+\part[5] Find $f'(x)$ if $f(x)=\sqrt{4x^2-7x}$
+
+\vfill
+
+
+\part[5] Find $y'$ if $y=\dfrac{3}{4x^2}+\dfrac{1}{\sqrt[3]{x}}+e^6$
+
+\vfill
+
+\part[4] Find $g'(x)$ if $g(x)=8e^xx^3$
+
+\vfill
+
+
+
+
+\end{parts}
+\newpage
+
+
+
+
+\question[6] Find $f''(x)$ if $f(x)=(x^2+1)^7$. You do not need to simplify your final answer.
+
+\newpage
+
+
+\question Clearly mark the correct answer(s) for each of the following by completely filling in the
+appropriate bubble. \textbf{No justification is needed.}
+
+
+
+
+\begin{parts}
+
+\part[2] \textbf{(Multiple Choice-Choose one)} Let $N(t)$ represent a country's national debt at
+time $t$ years after 2010. Suppose the country finds that in 2022 ($t=12$), the national debt is
+rising, but more and more slowly. Which of the following is true?
+
+\begin{itemize}[label={}]
+\item \chooseone $N'(12)$ and $N''(12)$ are both positive.
+\item \chooseone $N'(12)$ and $N''(12)$ are both negative.
+\item \chooseone $N'(12)$ is positive, while $N''(12)$ is negative.
+\item \chooseone $N'(12)$ is negative, while $N''(12)$ is positive.
+\end{itemize}
+
+
+\vfill
+
+
+\part[2] \textbf{(Multiple Choice-Choose one)} Let $f(x,y)=\ln(y)+\dfrac{1}{x^2+1}$. Which of the
+following is the domain of $f(x,y)$?
+
+     \vspace{0.15in}
+\begin{itemize}[label={}]
+\item \chooseone $\{(x,y)|\, x\neq 0, y\geq0\}$ \medskip
+\item \chooseone $\{(x,y)|\,y>0\}$ \medskip
+\item \chooseone $\{(x,y)|\,x\neq -1, y\geq 0\}$ \medskip
+\item \chooseone $\{(x,y)|\,x\neq -1, y>0\}$\medskip
+\end{itemize}
+
+
+\vfill
+
+
+
+
+\part[2] \textbf{(True/False)} An equation for the tangent line of $f(x)=2x^2+3x$ at $x=-2$ is
+$y=-5x-8$.
+\begin{itemize}[label={}]
+\item \chooseone True\medskip
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+\part[2] \textbf{(Multiple Choice-Choose one)} On a summer afternoon, a city's electricity
+consumption is given by the rate
+$E(t)$
+ in units per hour, where $t$ is the number of hours after noon ($0\leq t \leq 6$).
+Which of the following represents the total consumption of electricity between the hours of 1
+p.m. and 4 p.m.?
+\begin{itemize}[label={}]
+\item \chooseone $\displaystyle \int_0^4 E(t)\; dt$ \medskip
+\item \chooseone $\displaystyle \int_1^4 E(t)\; dt$ \medskip
+\item \chooseone $E(4)-E(0)$\medskip
+\item \chooseone $E(4)-E(1)$\medskip
+\item \chooseone None of the above.
+\end{itemize}
+
+\newpage
+
+
+
+
+\part[2] \textbf{(Multiple Choice-Choose one)} Suppose a study indicates that the distribution of
+income for basketball players given by the Lorenz curve $L(x)=x^3$. Suppose the Gini index for
+football players is $0.3$. Which profession has the more equal distribution of income?
+
+\begin{itemize}[label={}]
+\item \chooseone Basketball players \medskip
+\item \chooseone Football players\medskip
+\item \chooseone They are the same.
+\end{itemize}
+
+\vfill
+
+\part[2] \textbf{(Multiple Choice-Choose one)} If $g'(x) = 4e^{2x}$ and $g(0)=5$, what is $g(x)$?
+      \vspace{0.15in}
+\begin{itemize}[label={}]
+\item \chooseone $g(x)=2e^{2x}+3$\medskip
+\item \chooseone $g(x)=4e^{2x}+3$\medskip
+\item \chooseone $g(x)=2e^{2x}+5$ \medskip
+\item \chooseone $g(x)=4e^{2x}+5$ \medskip
+\item \chooseone None of the above.
+\end{itemize}
+
+\vfill
+
+\part[2] \textbf{(Multiple Choice-Choose one)} Which of the following integrals correctly
+computes the shaded area between $y=x^2+1$ and $y=4-2x$ (shown below)?
+
+\begin{minipage}{.4\textwidth}
+\begin{itemize}[label={}]
+\item \chooseone $\displaystyle \int_{2}^{10} (x^2-3-2x)dx $\medskip
+\item \chooseone $\displaystyle \int_{-3}^1 (x^2-3-2x)dx $\medskip
+\item \chooseone $\displaystyle \int_{-3}^1 (5-2x-x^2)dx $\medskip
+\item \chooseone $\displaystyle \int_{-3}^1 (3-2x-x^2)dx $\medskip
+\item \chooseone None of the above.
+\end{itemize}
+\end{minipage}
+\begin{minipage}{.5\textwidth}
+
+\begin{tikzpicture}[scale=1]
+\begin{axis}[axis on top=true,axis lines=middle,axis line style = thick,
+        xlabel=$x$,
+        ylabel=$y$,
+        enlargelimits,
+        ytick=\empty,
+        xtick=\empty
+        ]
+
+\addplot[name path=F,black, very thick,<->,domain={-4:2}] {4-2*x};
+
+\addplot[name path=G,black,very thick,<->, domain={-4:2}] {x^2+1};
+
+
+\addplot[color=gray!30]fill between[of=G and F, soft clip={domain=-3:1}];
+
+
+%\node at (axis cs:2,2.45){};
+\end{axis}
+\end{tikzpicture}
+
+\end{minipage}
+\vfill
+
+\end{parts}
+
+\newpage
+
+\question[8] Find the average value of $f(x)=6x+\dfrac{3}{4x}$ on $[2,5]$. Show all work. You do
+not need to simplify your final numerical answer.
+
+\newpage
+
+\question[8]
+A concert venue seats 200 people. When they price the tickets at $\$60$, all 200 tickets will sell.
+They estimate that for each $\$3$ increase in price, they will sell 5 fewer tickets. Find the price
+of concert ticket which will maximize their revenue. Justify your solution gives the maximum
+revenue. Show all work.
+
+
+
+
+\newpage
+
+
+
+
+\question The demand function $d(x)$ and supply function $s(x)$ for a particular commodity are
+given as:
+$$d(x)=330-2x, \; \; s(x)=3x^2+x$$
+\begin{parts}
+\part[5] Find the \textbf{consumers' surplus} at demand level $A=5$. You do not need to simplify
+your final numerical answer. Show all work.
+\vfill
+\part[5] Find the \textbf{producers' surplus} at demand level $A=5$. You do not need to simplify
+your final numerical answer. Show all work.
+\vfill
+\part[3] Find the market demand (the positive value of $x$ at which the demand function equals
+the supply function). Show all work.
+
+\vfill
+\end{parts}
+
+
+\newpage
+
+\question For $f(x,y)=6x^2-2x^3+3y^2+6xy$:
+
+\begin{parts}
+\part[5] Find $f_x, f_y, f_{xx}, f_{yy}$, and $f_{xy}$.
+\vspace{3in}
+
+\part[4] The critical points of $f(x,y)$ are $(0,0)$ and $(1,-1)$. Determine, using the $D$-test, if
+each point corresponds to a relative maximum, relative minimum, or saddle point. Show all
+work.
+
+\end{parts}
+
+\newpage
+
+\question[8] Evaluate the following improper integral or show that it is divergent. Show all work.
+
+$\ds \int_0^\infty \dfrac{2e^{x}+4e^{2x}}{e^{3x}}dx$
+
+\newpage
+
+\question For $f(x,y)=x^3-4xy-8y+3$:
+
+\begin{parts}
+
+\part[1] Compute $f(-1,2)$. Simplify your answer to a single number.
+
+\vspace{1.5in}
+
+\part[2] Find the partial derivative $f_x$.
+
+\vspace{1.5in}
+
+\part[2] Find the partial derivative $f_y$.
+
+\vspace{1.5in}
+
+\part[3] Find the critical point(s) of $f(x,y)$. Write each in the form $(x,y)$. Show all work.
+
+\end{parts}
+
+
+
+
+\newpage
+
+\question
+Use the graph of $y=f'(x)$ to answer the following. No justification is required.
+
+\begin{tikzpicture}[scale=1]
+\draw[gray!60] (-6, -4) grid[step=1] (7, 5);
+
+\draw[<->,thick,black] (-6.5,0)--(7.5,0) node[right]{$x$};
+\draw[<->, thick,black] (0,-4.5)--(0,5.5) node[above]{$y$};
+\foreach \x in {-6,-5,...,7}
+\draw[thick] (\x,-.1) --(\x,.1) node[below] { \x};
+\foreach \y in {-4,-3,...,5}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] { \y};
+\draw[domain=-4.5:5.7,samples=100, very thick,<->,color=blue] plot
+({\x},{(\x+4)/10*(\x-1)*(\x-5)});
+\node[color=blue] at (5.7,3.5) {$y=f'(x)$};
+\end{tikzpicture}
+
+Again, \textbf{this is the graph of the derivative of $f(x)$.}
+
+\begin{parts}
+​        \part[2] On which interval(s) is $f(x)$ decreasing?
+ \vfill
+\part[2] At which $x$-value(s) does $f(x)$ have a horizontal tangent line?
+\vfill
+
+​         \part[2] What is $\displaystyle \lim_{h\to0}\frac{f(h)-f(0)}{h}$?
+  \vfill
+​        \part[2] Is $f(x)$ concave up or concave down at $x=2$?
+ \vfill
+
+
+
+
+    \end{parts}
+
+
+
+
+    \end{questions}
+
+\end{document}

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm1-PracticeA.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm1-PracticeA.tex
@@ -1,0 +1,379 @@
+\documentclass[addpoints,12pt]{exam}
+\newcommand{\ds}{\displaystyle}
+\usepackage[margin=0.8in]{geometry}
+\usepackage{subcaption}
+\usepackage{tikz}
+\usepackage{amssymb,amsmath,graphicx,wrapfig,verbatim,wasysym, enumitem,psfragx,color}
+\usepackage{multicol}
+
+\usepackage{xpatch}
+
+\makeatletter
+\xpatchcmd{\@fillin@relay}
+  {\hbox to #1{\hrulefill}\fi}
+  {\hbox{\framebox[#1]{\rule{0pt}{2ex}}}\fi}
+  {}{}
+\makeatother
+
+%\usepackage{fancyhdr}
+%\setlength{\headheight}{13.6pt}
+%\pagestyle{fancy}
+%\lhead{Math 222}
+%\chead{ Midterm 1 }
+
+%\rhead{Spring 2022}
+
+\def\FillInBlank{\rule{3truein} {.01truein}}
+
+
+% Choose one option (bubbles)
+\newcommand{\chooseone}{{\Large$\Circle$\ \ }}
+
+
+\newcommand{\myleft}{\makebox[.4\textwidth]{First Name:\enspace\hrulefill}}
+\newcommand{\myright}{\makebox[.4\textwidth]{Last Name:\enspace\hrulefill}}
+\header{\oddeven{\myleft}{}}
+    {}
+    {\oddeven{\myright}{}}
+
+\footrule
+
+\footer{Math 211}
+     {Midterm 1 Practice Exam}
+     {Page \thepage\ of \numpages}
+
+\begin{document}
+
+\begin{questions}
+
+
+\question Clearly mark the correct answer for each of the following by completely filling in the
+appropriate bubble. \textbf{No justification is needed.}
+
+
+\begin{parts}
+
+\part[2] \textbf{(Multiple Choice)} The cost of producing $x$ ounces of gold from a new gold
+mine is $C(x)$ dollars. What does the statement $C'(500) = 17$ mean?
+
+
+
+
+\begin{itemize}[label={}]
+\item \chooseone The total cost to produce 17 ounces of gold is approximately \$500.
+
+\item \chooseone After 500 ounces of gold have been produced, the average production cost is
+\$17/ounce. So the cost of producing 500 ounces is about \$17/ounce.
+
+\item \chooseone After 500 ounces of gold have been produced, the rate at which the
+production cost is increasing is \$17/ounce. So the cost of producing the 500th (or 501st) ounce
+is about \$17.
+\item \chooseone After 17 ounces of gold have been produced, the average production cost is
+\$500/ounce. So the cost of producing 17 ounces is about \$500/ounce.
+\end{itemize}
+
+\medskip
+
+
+
+
+\part[2] \textbf{(True/False)} If $f(t)$ is the function describing (in feet) the water level in a lake at
+time $t$ (where $t$ is in hours), and $f'(3)=10$ and $f''(3)=-2$, then the water level is rising at
+$t=3$, but the rate is slowing.
+
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+
+
+
+\part[2] \textbf{(True/False)} The graph below describes a function in $x$.
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+\begin{tikzpicture}[scale=.8]
+\draw[gray!40] (-5, -5) grid[step=1] (5, 5);
+\draw[<->,thick,black] (-6,0)--(6,0) node[right]{$x$};
+\draw[<->, thick,black] (0,-6)--(0,6) node[above]{$y$};
+\foreach \x in {-5,-4,...,5}
+\draw[thick] (\x,-.1) --(\x,.1) node[below]{\x};
+\foreach \y in {-5,-4,...,5}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] {\y};
+\draw[domain=-3.5:1,samples=100, thick,<-] plot ({\x},{-(\x+1)^2+2});
+\draw[domain=1:5,samples=100,thick,->] plot ({\x},{(\x/2+0.5});
+\draw[fill=black] (3,4) circle[radius=0.25em];
+\draw[fill=black] (1,-2) circle[radius=0.25em];
+
+\draw[fill=white,thick] (3,2) circle[radius=0.25em];
+\draw[fill=white,thick] (1,1) circle[radius=0.25em];
+\end{tikzpicture}
+
+
+
+
+\vfill
+
+\end{parts}
+
+\newpage
+
+
+\newpage
+
+
+\question Calculate the derivative of each function. You do not need to simplify your answer.
+
+\begin{parts}
+
+
+
+
+\part[5] $g(x)=\dfrac{4}{x^3} + 7$
+\vspace{2in}
+
+\part[5] $F(x)=(x+1)(2x+3)$
+
+\vspace{2in}
+
+\part[5] $r(x)=\ds\sqrt{2x-3}$
+
+\vspace{2in}
+
+\part[5] $f(x)=(x^2+2x)^8$
+
+\vspace{2in}
+
+
+
+
+\end{parts}
+
+\newpage
+
+
+\question Find each limit. Show all work. Simplify your final answers.
+
+\begin{parts}
+
+\part[4] $\ds \lim_{x\to 3} \dfrac{ x^2-x-6}{x^2+2x-15}$
+
+\vfill
+
+
+\part[4] $\displaystyle \lim_{x\to 0}\dfrac{3x-5}{x^2+3}$
+
+\vfill
+
+\end{parts}
+
+\newpage
+
+\question[11] Find an equation for the tangent line of $f(x)=x^3-5x^2+2$ at $x=1$. Show all
+work.
+
+\newpage
+
+\question[8] Find $f''(x)$ of $f(x)=4x(x+1)$. You do not need to simplify your final answer. Show
+all work.
+
+
+\newpage
+
+
+
+
+\question A baseball bat manufacturer finds that the cost of making $x$ bats is $C(x)=40+10x$,
+and the revenue in selling $x$ bats is $R(x)=28x-2x^2$.
+
+\begin{parts}
+\part[5] Find all $x$ value(s) where $R(x)=C(x)$. Show your work.
+
+\vspace{2in}
+
+\part[3] Find the \textbf{marginal revenue function} $MR(x)$ and evaluate $MR(2)$. You do not
+need to simplify your final numerical answer.
+
+\vspace{2in}
+
+\part[2] Find the \textbf{average cost function} $AC(x)$.
+
+\vspace{1in}
+
+
+
+
+\part[4] Find the \textbf{marginal average cost function} $MAC(x)$ and evaluate $MAC(2)$. You
+do not need to simplify your final numerical answer.
+
+\vfill
+
+\vfill
+
+
+
+
+\end{parts}
+
+\newpage
+
+
+\question Consider the function $y=f(x)$ below. Answer the following questions.
+​
+​        \begin{tikzpicture}[scale=.99]
+​        ​        \draw[gray!60] (-5, -5) grid[step=1] (5, 5);
+​        ​        \draw[<->,thick,black] (-5,0)--(5,0) node[right]{$x$};
+​        ​        \draw[<->, thick,black] (0,-5)--(0,5) node[above]{$y$};
+​        ​        \foreach \x in {-5,-4,...,5}
+​        ​        \draw[thick] (\x,-.1) --(\x,.1) node[below] {\small \x};
+​        ​        \foreach \y in {-5,-4,...,5}
+​        ​        \draw[thick] (-.1,\y) --(.1,\y) node[left] {\small \y};
+​        ​        \draw[domain=-3.5:4.25,samples=200,thick,<->] plot
+({\x},{(3*\x*\x*\x*\x-8*\x*\x*\x-30*\x*\x+72*\x)/50});
+​        ​        \node at (4,2.7) {$y=f(x)$};
+​        \end{tikzpicture}
+
+
+\begin{parts}
+\part[2] For which $x$-value(s) is $f'(x)=0$? Briefly (one sentence) explain your answer.
+
+\vspace{1in}
+
+\part[2] Is $f'(-1)$ positive, negative, or zero? Briefly (one sentence) explain your answer.
+
+\vspace{1in}
+
+
+\part[2] Is $f'(2)$ positive, negative, or zero? Briefly (one sentence) explain your answer.
+
+\vspace{1in}
+
+\end{parts}
+
+
+
+
+\newpage
+
+\question[10] Use the (limit) definition of the derivative,
+$$\displaystyle f'(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h},$$ to compute $f'(x)$ for $f(x)=3x^2-4$.
+
+\newpage
+
+
+\question For the graph of $y=f(x)$ below:
+
+\begin{tikzpicture}[scale=.7]
+\draw[gray!60] (-6, -6) grid[step=1] (6, 7);
+\draw[<->,thick,black] (-7,0)--(7,0) node[right]{$x$};
+\draw[<->, thick,black] (0,-7)--(0,7) node[above]{$y$};
+\foreach \x in {-6,-5,...,6}
+\draw[thick] (\x,-.1) --(\x,.1) node[below] {\small \x};
+\foreach \y in {-6,-5,...,7}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] {\small \y};
+ \draw[domain=-6:0.955,samples=100, thick,<->] plot ({\x},{-(\x*\x-2*\x)/(\x*\x*\x-1)+1});
+ \draw[domain=1.17:6,samples=100,thick,<->] plot ({\x},{-3*(\x*\x-2*\x)*\x/(\x*\x*\x-1)+2});
+\draw[fill=white,thick] (3,1) circle[radius=0.3em];
+\draw[fill=black] (3,2) circle[radius=0.3em];
+\end{tikzpicture}
+
+
+\begin{parts}
+
+\part[2] Give all $x$-values where $f(x)$ is discontinuous.
+
+\vspace{1in}
+
+\part[4] Find each value, if possible. If not possible, write DNE.
+\vspace{0.5in}
+
+(a) $\displaystyle \lim_{x\to 1^-} f(x)=$
+
+\vspace{0.5in}
+
+(b) $\displaystyle \lim_{x\to 1^+} f(x)=$
+\vspace{0.5in}
+
+
+(c) $\displaystyle \lim_{x\to 1} f(x)=$
+\vspace{0.5in}
+
+(d) $\displaystyle \lim_{x\to 3} f(x)=$
+\vspace{0.5in}
+
+
+
+
+\end{parts}
+
+\newpage
+
+
+\question
+\begin{parts}
+
+\part[4] Given the graph of $y=f(x)$ below, give the domain and the range of $f(x)$. Use interval
+notation.
+
+\begin{minipage}{0.4\textwidth}
+
+
+Domain:
+
+ \vspace{1in}
+
+ Range:
+
+ \vspace{2in}
+
+\end{minipage}
+\begin{minipage}{0.4\textwidth}
+\begin{tikzpicture}[scale=.8]
+\draw[gray!40] (-4, -4) grid[step=1] (6, 6);
+\draw[<->,thick,black] (-5,0)--(7,0) node[right]{$x$};
+\draw[<->, thick,black] (0,-5)--(0,7) node[above]{$y$};
+\foreach \x in {-4,-3,...,6}
+\draw[thick] (\x,-.1) --(\x,.1) node[below]{\x};
+\foreach \y in {-4,-3,...,6}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] {\y};
+\draw[domain=-2:1,samples=100, thick,-] plot ({\x},{(\x+1)^2+1});
+\draw[domain=1:5,samples=100,thick,-] plot ({\x},{\x/2-1.5});
+\draw[fill=black] (-2,2) circle[radius=0.25em];
+\draw[fill=black] (1,5) circle[radius=0.25em];
+\draw[fill=black] (5,1) circle[radius=0.25em];
+\draw[fill=white,thick] (1,-1) circle[radius=0.25em];
+\end{tikzpicture}
+\end{minipage}
+
+\part[4] Simplify $\dfrac{x^2}{4\sqrt{x}}$ to the form $ax^b$, where $a$ and $b$ are both
+numbers.
+\vspace{1.5in}
+
+\part[3] For $f(x)=2x-1$ and $g(x)=\sqrt{x+3}$, Write down expressions for each function
+composition. You do not need to simplify.
+
+\vspace{0.5in}
+
+$f(g(x))=$
+
+\vspace{0.5in}
+
+$g(f(x))=$
+
+
+\vspace{0.5in}
+
+$f(f(x))=$
+
+\end{parts}
+
+
+
+
+\end{questions}
+
+\end{document}

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm1-PracticeB.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm1-PracticeB.tex
@@ -1,0 +1,356 @@
+\documentclass[addpoints,12pt]{exam}
+\newcommand{\ds}{\displaystyle}
+\usepackage[margin=0.8in]{geometry}
+\usepackage{subcaption}
+\usepackage{tikz}
+
+\usepackage{amssymb,amsmath,graphicx,wrapfig,verbatim,wasysym, enumitem,psfragx,color}
+\usepackage{multicol}
+
+\usepackage{xpatch}
+
+\makeatletter
+\xpatchcmd{\@fillin@relay}
+  {\hbox to #1{\hrulefill}\fi}
+  {\hbox{\framebox[#1]{\rule{0pt}{2ex}}}\fi}
+  {}{}
+\makeatother
+
+%\usepackage{fancyhdr}
+%\setlength{\headheight}{13.6pt}
+%\pagestyle{fancy}
+%\lhead{Math 222}
+%\chead{ Midterm 1 }
+%\rhead{Spring 2022}
+
+\def\FillInBlank{\rule{3truein} {.01truein}}
+
+
+
+
+% Choose one option (bubbles)
+\newcommand{\chooseone}{{\Large$\Circle$\ \ }}
+% Choose multiple options (squares)
+\newcommand{\choosemany}{{\Large$\Square$\ \ }}
+
+
+\newcommand{\myleft}{\makebox[.4\textwidth]{First Name:\enspace\hrulefill}}
+\newcommand{\myright}{\makebox[.4\textwidth]{Last Name:\enspace\hrulefill}}
+\header{\oddeven{\myleft}{}}
+    {}
+    {\oddeven{\myright}{}}
+
+\footrule
+
+\footer{Math 211}
+     {Midterm 1 Practice Exam}
+     {Page \thepage\ of \numpages}
+
+\begin{document}
+
+\begin{questions}
+
+
+\question Clearly mark the correct answer(s) for each of the following by completely filling in the
+appropriate bubble. \textbf{No justification is needed.}
+
+
+\begin{parts}
+
+\part[2] \textbf{(Multiple Choice-Choose one)} Where does $f(x)=x-3\sqrt{x}$ have a horizontal
+tangent line?
+
+\begin{itemize}[label={}]
+\item \chooseone $x=0$
+\item \chooseone $x=1$
+\item \chooseone $x=\frac{1}{2}$
+\item \chooseone $x=\frac{9}{4}$
+\item \chooseone None of the above.
+\end{itemize}
+
+\medskip
+
+
+
+
+\part[2] \textbf{(True/False)} If $f(x)=x^2+2$ and $g(x)=4x+3$, $f(g(x))=g(f(x))$.
+
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+
+
+
+\part[2] \textbf{(Choose all that apply)} Given the graph of $y=f(x)$ below, where is $f(x)$
+discontinuous?
+\begin{itemize}[label={}]
+\item \choosemany $x=-1$
+\item \choosemany $x=1$
+\item \choosemany $x=3$
+
+\item \choosemany None of the above.
+\end{itemize}
+
+\begin{tikzpicture}[scale=.8]
+\draw[gray!40] (-5, -5) grid[step=1] (5, 5);
+\draw[<->,thick,black] (-6,0)--(6,0) node[right]{$x$};
+\draw[<->, thick,black] (0,-6)--(0,6) node[above]{$y$};
+\foreach \x in {-5,-4,...,5}
+\draw[thick] (\x,-.1) --(\x,.1) node[below]{\x};
+\foreach \y in {-5,-4,...,5}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] {\y};
+\draw[domain=1:5,samples=100, thick,->] plot ({\x},{-(\x+1)+5});
+\draw[domain=-1:1,samples=100, thick,-] plot ({\x},{3*\x});
+\draw[domain=-5:-1,samples=100,thick,<-] plot ({\x},{(-\x/2+0.5});
+\draw[fill=black] (3,4) circle[radius=0.25em];
+\draw[fill=black] (-1,1) circle[radius=0.25em];
+\draw[fill=white,thick] (3,1) circle[radius=0.25em];
+\draw[fill=white,thick] (-1,-3) circle[radius=0.25em];
+\node at (5,-1.5) {$f(x)$};
+\end{tikzpicture}
+
+
+
+
+\vfill
+
+\end{parts}
+
+\newpage
+
+
+\newpage
+
+
+\question Calculate the derivative of each function. You do not need to simplify your answer.
+
+\begin{parts}
+
+
+
+
+\part[5] $\ds g(x)=x^3-3(x^2+10^2)$
+\vspace{2in}
+
+\part[5] $\ds r(x)=\sqrt{x+\sqrt{x}}$
+
+\vspace{2in}
+
+\part[5] $\ds f(t)=\frac{7}{t^{4/3}}-8t$
+
+\vspace{2in}
+
+\part[5] $f(x)=(x^3+2x-7)(x^4-3x^2+x)$
+
+\vspace{2in}
+
+
+
+
+\end{parts}
+
+\newpage
+
+
+\question Given the graph of $f(x)$ and the graph of $g(x)$ below:
+
+
+\begin{minipage}{.45\textwidth}
+\begin{tikzpicture}[scale=.65]
+\draw[gray!40] (-5, -5) grid[step=1] (5, 6);
+\draw[<->,thick,black] (-6,0)--(6,0) node[right]{$x$};
+\draw[<->, thick,black] (0,-6)--(0,7) node[above]{$y$};
+\foreach \x in {-5,-4,...,5}
+\draw[thick] (\x,-.1) --(\x,.1) node[below]{\x};
+\foreach \y in {-5,-4,...,6}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] {\y};
+\draw[domain=-4:3,samples=100, thick,-] plot ({\x},{2*abs(\x+2)-4})node[above]{$y=f(x)$};
+\draw[fill=black] (-4,0) circle[radius=0.25em];
+\draw[fill=white,thick] (3,6) circle[radius=0.25em];
+\end{tikzpicture}
+\end{minipage}
+\begin{minipage}{.45\textwidth}
+\begin{tikzpicture}[scale=.65]
+\draw[gray!40] (-5, -5) grid[step=1] (5, 5);
+\draw[<->,thick,black] (-6,0)--(6,0) node[right]{$x$};
+\draw[<->, thick,black] (0,-6)--(0,6) node[above]{$y$};
+\foreach \x in {-5,-4,...,5}
+
+\draw[thick] (\x,-.1) --(\x,.1) node[below]{\x};
+\foreach \y in {-5,-4,...,5}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] {\y};
+\draw[domain=-3:-1,samples=100, thick,-] plot ({\x},{3*\x+5});
+\draw[domain=-1:5,samples=100, thick,-] plot ({\x},{-1/3*\x+5/3})node[above]{$y=g(x)$};
+\draw[fill=white,thick] (-1,2) circle[radius=0.25em];
+\draw[fill=black] (-3,-4) circle[radius=0.25em];
+\draw[fill=black] (5,0) circle[radius=0.25em];
+
+\end{tikzpicture}
+
+\end{minipage}
+
+\begin{parts}
+\part[2] Give the domain and range of $f(x)$. Use interval notation.
+\vspace{1in}
+
+\part[2] Give the domain and range of $g(x)$. Use interval notation.
+\vspace{1in}
+
+\part[2] What is $g(f(-3))$?
+\vspace{1in}
+
+\part[2] Find $F'(2)$, where $F(x)=f(x)g(x)$. You do not need to simplify your final numerical
+answer.
+\vspace{1in}
+\end{parts}
+
+\newpage
+
+
+
+
+Find each limit. Show all work. Simplify your final answers.
+
+\begin{parts}
+
+\part[4] $\displaystyle\lim_{x\to 1} \dfrac{x^2-4x+4}{x^3+5x^2-14x}$
+
+\vfill
+
+
+\part[4] $\displaystyle\lim_{x\to 4} \dfrac{x^2+x-20}{2x^2-6x-8}$
+
+\vfill
+
+\end{parts}
+
+\newpage
+
+\question[11] Find an equation for the tangent line of the function $f(x)=x-2x^2$ at $x=3$. Show
+all work.
+
+\newpage
+
+\question[8] Find $g''(x)$ of $g(x)=4\sqrt{x}-\dfrac{1}{x^2}$. You do not need to simplify your final
+answer. Show all work.
+
+
+\newpage
+
+
+
+
+\question Suppose a USB manufacturer finds that the cost of producing $x$ total USBs is
+$C(x)=40+24x^{1/3}$.
+\begin{parts}
+  \part[4] Find the marginal cost function $MC(x)$ and evaluate it at $x=8$. Simplify your
+answer.
+  \vfill
+
+  \part[5] Find the marginal average cost function $MAC(x)$ and evaluate it at $x=8.$ Simplify
+your answer.
+   \vfill
+\end{parts}
+
+
+\newpage
+
+
+\question Given the graph of $f(x)$ below, find each limit. Write $\infty, -\infty$, or DNE if
+applicable.
+
+\begin{tikzpicture}[scale=.65]
+\draw[gray!60] (-6, -6) grid[step=1] (6, 7);
+\draw[<->,thick,black] (-7,0)--(7,0) node[right]{$x$};
+\draw[<->, thick,black] (0,-7)--(0,7) node[above]{$y$};
+\foreach \x in {-6,-5,...,6}
+\draw[thick] (\x,-.1) --(\x,.1) node[below] {\small \x};
+
+\foreach \y in {-6,-5,...,7}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] {\small \y};
+ \draw[domain=-6:1.88,samples=100, thick,<->] plot ({\x},{-\x*\x/(\x-2)/6+2});
+ \draw[domain=2.1:6,samples=100,thick,<->] plot ({\x},{\x*\x/(\x-2)/6-1/2});
+\draw[fill=white,thick] (3,1) circle[radius=0.3em];
+\draw[fill=white,thick] (0,2) circle[radius=0.3em];
+\draw[fill=black] (3,2) circle[radius=0.3em];
+\end{tikzpicture}
+
+\vspace{0.25in}
+
+\begin{parts}
+\part[2] $\ds \lim_{x\to 3^-}f(x)=$
+​        \vspace{0.5in}
+
+\part[2]$\ds \lim_{x\to 3^+}f(x)=$
+​       ​        \vspace{0.5in}
+
+
+\part[2]$\ds \lim_{x\to 3}f(x)=$
+​       \vspace{0.5in}
+
+
+\part[2]$\ds \lim_{x\to 0}f(x)=$
+​       \vspace{0.5in}
+
+
+\part[2]$\ds \lim_{x\to 2^-}f(x)=$
+\vspace{0.5in}
+
+
+\part[2]$\ds \lim_{x\to 2^+}f(x)=$
+\vspace{0.5in}
+
+
+\part[2]$\ds \lim_{x\to 2}f(x)=$
+\vspace{0.5in}
+
+
+\end{parts}
+
+\newpage
+
+\question[10] Use the limit definition of the derivative to compute $f'(x)$ for $f(x)=3x+x^2$.
+
+\newpage
+
+
+\question Suppose the graph below is $f'(x)$. Assume each tick mark is 1 unit.
+
+\begin{tikzpicture}[scale=1.5]
+​        \draw[<->,thick] (-2.2,0) -- (3.5,0) node[right] {$x$};
+​        \draw[<->,thick] (0,-2) -- (0,3.5) node[above] {$y$};
+​        \foreach \x in {-4,-3,...,6}
+​        \draw[scale=0.5] (\x,-.2) --(\x,.2);
+​        \foreach \y in {-3,-2,...,6}
+​        \draw[scale=0.5] (-.2,\y) --(.2,\y);
+​        \draw[<->, scale=1,domain=-2.1:3.25,smooth,variable=\x,blue, thick] plot
+({\x},{-.25*\x*(\x-1.5)*(\x+2)*(\x-3)}) node[above]{$y=f'(x)$};
+​        \end{tikzpicture}
+
+​       \begin{parts}
+​       ​      \part[2] At which $x$-values does $f(x)$ have a horizontal tangent line? Briefly
+explain your answer.
+  \vspace{1.5in}
+
+​         ​      \part[2] On which intervals is $f(x)$ increasing? Briefly explain your answer.
+    \vspace{1.5in}
+
+
+​       ​      \part[2] On which intervals is $f(x)$ decreasing?Briefly explain your answer.
+  \vspace{1.5in}
+​       \end{parts}
+​
+​
+
+
+
+
+\newpage
+
+\end{questions}
+
+\end{document}

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm1.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm1.tex
@@ -1,0 +1,369 @@
+\documentclass[addpoints,12pt]{exam}
+\newcommand{\ds}{\displaystyle}
+\usepackage[margin=0.8in]{geometry}
+\usepackage{subcaption}
+\usepackage{tikz}
+\usepackage{amssymb,amsmath,graphicx,wrapfig,verbatim,wasysym, enumitem,psfragx,color}
+\usepackage{multicol}
+
+\usepackage{pgf,tikz,pgfplots}
+\usepackage{stmaryrd}
+\usetikzlibrary{arrows, shapes.geometric, matrix, turtle, plotmarks}
+
+%\usepackage{fancyhdr}
+%\setlength{\headheight}{13.6pt}
+%\pagestyle{fancy}
+%\lhead{Math 222}
+%\chead{ Midterm 1 }
+%\rhead{Spring 2022}
+
+\def\FillInBlank{\rule{3truein} {.01truein}}
+
+
+
+
+% Choose one option (bubbles)
+\newcommand{\chooseone}{{\Large$\Circle$\ \ }}
+% Choose multiple options (squares)
+\newcommand{\choosemany}{{\Large$\Square$\ \ }}
+
+
+\newcommand{\myleft}{\makebox[.4\textwidth]{First Name:\enspace\hrulefill}}
+\newcommand{\myright}{\makebox[.4\textwidth]{Last Name:\enspace\hrulefill}}
+\header{\oddeven{\myleft}{}}
+    {}
+    {\oddeven{\myright}{}}
+
+\footrule
+
+\footer{Math 211}
+     {Midterm 1 - Fall 2024}
+
+    {Page \thepage\ of \numpages}
+
+\begin{document}
+
+\begin{questions}
+
+\question Clearly mark the correct answer(s) for each of the following by completely filling in the
+appropriate bubble. \textbf{No justification is needed.}
+
+
+
+
+\begin{parts}
+
+
+
+
+\part[2] \textbf{(Multiple Choice-Choose one)} Let $f(x)$ and $g(x)$ be two functions such that
+$f(2) = -3$, $g(2) = 7$, $f'(2) = 3$, $g'(2) = 10$, and $f'(7) = 4$. Which of the following is the
+instantaneous rate of change of $f(g(x))$ when $x = 2$?
+
+\begin{itemize}[label={}]
+\item \chooseone 3
+\item \chooseone 30
+\item \chooseone 40
+\item \chooseone 210
+\item \chooseone None of the above.
+\end{itemize}
+
+
+\vfill
+
+
+\part[2] \textbf{(Multiple Choice-Choose one)} Suppose $f(t)$ represents the temperature $t$
+hours after noon. Suppose the temperature at 3:00pm ($t = 3$) is rising increasingly rapidly.
+Which of the following is true?
+      \vspace{0.15in}
+\begin{itemize}[label={}]
+\item \chooseone $f'(3)$ is negative, while $f''(3)$ is positive.
+\item \chooseone $f'(3)$ is positive, while $f''(3)$ is negative.
+\item \chooseone $f'(3)$ and $f''(3)$ are both positive.
+\item \chooseone $f'(3)$ and $f''(3)$ are both negative.
+\end{itemize}
+
+\vfill
+
+
+
+
+\part[2] \textbf{(True/False)} Suppose $g(x)$ is a function with $\displaystyle\lim_{ x \to 4^+}
+g(x) = 1$, $\displaystyle\lim_{x\to 4^-}g(x)=2$, and $g(4) = 2$. Then $g(x)$ is continuous at
+$x=4$.
+
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+
+\newpage
+
+
+
+
+\part[2] \textbf{(Multiple Choice-Choose one)} Which of the following is equal to
+$\dfrac{10}{\sqrt[3]{8x^2}}$?
+\begin{itemize}[label={}]
+\item \chooseone $20x^{6}$
+\item \chooseone $20x^{-3/2}$
+\item \chooseone $5x^{-3/2}$
+\item \chooseone None of the above.
+\end{itemize}
+
+\vfill
+
+
+\part[2] \textbf{(Multiple Choice-Choose one)} What is the domain of the function\\ $y=f(x)$
+shown below?
+
+\begin{minipage}{.4\textwidth}
+\begin{itemize}[label={}]
+\item \chooseone $[1,6]$
+\item \chooseone $[-2,5]$
+\item \chooseone $(-2,2)\cup(2,5)$
+\item \chooseone $[-2,2)\cup(2,5]$
+
+\item \chooseone None of the above.
+\end{itemize}
+\end{minipage}
+\begin{minipage}{.5\textwidth}
+\begin{tikzpicture}[scale=.8]
+\draw[gray!40] (-3, 0) grid[step=1] (6, 6);
+\draw[<->,thick,black] (-3.5,0)--(6.5,0) node[right]{$x$};
+\draw[->, thick,black] (0,0)--(0,6.5) node[above]{$y$};
+\foreach \x in {-3,-2,...,6}
+\draw[thick] (\x,-.1) --(\x,.1) node[below]{\x};
+\foreach \y in {0,1,...,6}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] {\y};
+\draw[domain=2:5,samples=100, thick,-] plot ({\x},{-(\x-3)^2+6});
+\draw[domain=-2:2,samples=100,thick,-] plot ({\x},{\x/2+2});
+\draw[fill=black] (5,2) circle[radius=0.25em];
+\draw[fill=white,thick] (2,3) circle[radius=0.25em];
+\draw[fill=white,thick] (2,5) circle[radius=0.25em];
+\draw[fill=black] (-2,1) circle[radius=0.25em];
+\node at (5.2,5.25) {$y=f(x)$};
+\end{tikzpicture}
+
+\end{minipage}
+\vfill
+
+\end{parts}
+
+\newpage
+
+
+\question Calculate the derivative of each function. You do not need to simplify your answers.
+
+\begin{parts}
+
+\part[5] $f(x)=(x^3+2x-1)(x^2-10x)$
+
+\vfill
+
+
+
+
+\part[5] $g(x)=\dfrac{2}{7x^2}+3x^4+\sqrt{2}$
+
+\vfill
+
+\part[5] $r(t)=\sqrt[4]{t^2+t}$
+
+
+
+
+\vfill
+
+
+\part[5] $F(x)=(2x^6+x^2)^9+3x$
+
+
+
+
+\vfill
+
+\end{parts}
+
+\newpage
+
+
+
+
+\question For the graph of $y=f(x)$ below:
+
+\begin{tikzpicture}[scale=0.8]
+\draw[gray!60] (-6, -5) grid[step=1] (6, 6);
+\draw[->,thick,black] (-6.5,0)--(6.5,0) node[right]{$x$};
+\draw[->, thick,black] (0,-5.5)--(0,6.5) node[above]{$y$};
+\foreach \x in {-6,...,6}
+\draw[thick] (\x,-.1) --(\x,.1) node[below] {\small \x};
+\foreach \y in {-5,...,6}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] { \small \y};
+\draw[domain=-5:0.86,samples=100, very thick,<->] plot ({\x},{-2*\x*\x/(\x-1)-4});
+
+\draw[domain=1.24:3,samples=100, very thick,<-] plot ({\x},{2/(\x-1)-2 });
+\draw[domain=3:6, samples=100, very thick, ->] plot ({\x}, {2*\x-10});
+\draw[fill=black] (3,-1) circle[radius=0.3em];
+\draw[fill=white,very thick] (-1,-3) circle[radius=0.3em];
+\draw[fill=white,very thick] (3,-4) circle[radius=0.3em];
+\node at (6,2.5) {$y=f(x)$};
+%\draw[thick,dashed] (-2,-4)--(-2,4);
+\draw[thick,dashed] (1,-5.5)--(1,6.5);
+\end{tikzpicture}
+
+\begin{parts}
+
+\part[3] For which $x$-value(s) is $f(x)$ discontinuous?
+
+\vspace{0.75in}
+
+
+\part[6] Find each limit, if possible (use $+\infty$ or $-\infty$ if applicable). If not possible, write
+DNE.
+\vfill
+
+(a) $\displaystyle \lim_{x\to -1} f(x)=$
+
+\vfill
+
+(b) $\displaystyle \lim_{x\to 1^-} f(x)=$
+\vfill
+
+(c) $\displaystyle \lim_{x\to 3^{-}} f(x)=$
+
+\vfill
+
+(d) $\displaystyle \lim_{x\to 3^{+}} f(x)=$
+\vfill
+
+(e) $\displaystyle \lim_{x\to 3} f(x)=$
+\vfill
+
+(f) $\displaystyle \lim_{x\to 4} f(x)=$
+
+
+
+
+\end{parts}
+
+\newpage
+
+\question[8] Find $f''(x)$ for $f(x)=12\sqrt{x}(x+1)$. You do not need to simplify your final
+answer. Show all work.
+
+\newpage
+
+\question Suppose a table manufacturer determines that their cost function $C(x)$ (in dollars)
+for producing $x$ tables is $C(x)=30x+50$, while their revenue function $R(x)$ (in dollars) for
+selling $x$ tables is $R(x)=45x-x^2$.
+
+\begin{parts}
+
+\part[5] Find the \textbf{profit function} $P(x)$, then find the $x$-value(s) where $P(x)=0$. Show
+all work.
+
+\vspace{2in}
+
+\part[5] Find the \textbf{marginal revenue function} and evaluate it at $x=10$. You do not need
+to simplify your numerical answer. Show all work.
+
+\vspace{2in}
+
+\part[2] Find the \textbf{average cost function}.
+
+\vspace{1in}
+
+\part[5] Find the \textbf{marginal average cost function} and evaluate it at $x=10$. You do not
+need to simplify your numerical answer. Show all work.
+\end{parts}
+
+\vspace{2in}
+
+\newpage
+
+\question[11] Use the limit definition of the derivative to compute $f'(x)$, where $f(x)=2x^2-6x$.
+Show all work.
+
+
+\newpage
+
+\question
+
+Find each limit. Show all work. Simplify your final answers.
+
+\begin{parts}
+  \part[5] $\displaystyle \lim_{x\to 3} \dfrac{x^2+x-12}{2x-6}$
+
+  \vfill
+
+  \part[4] $\displaystyle \lim_{x\to 0}\dfrac{x^2+5x+4}{x^2+3x-4}$
+
+  \vfill
+\end{parts}
+
+\newpage
+
+
+\question[10] Find an equation for the tangent line of $f(x)=x^4+2x+4$ at $x=-1$. Show all work.
+
+
+\newpage
+
+
+
+
+\question Consider the function $y=f(x)$ below. Clearly mark the correct answer(s) for each of
+the following by completely filling in the appropriate bubble. \textbf{No justification is needed.}
+​
+​         \begin{tikzpicture}[scale=.99]
+​         ​       \draw[gray!60] (-5, -5) grid[step=1] (5, 5);
+​         ​       \draw[<->,thick,black] (-5.3,0)--(5.3,0) node[right]{$x$};
+​         ​       \draw[<->, thick,black] (0,-5.3)--(0,5.3) node[above]{$y$};
+​         ​       \foreach \x in {-5,-4,...,5}
+​         ​       \draw[thick] (\x,-.1) --(\x,.1) node[below] {\small \x};
+​         ​       \foreach \y in {-5,-4,...,5}
+​         ​       \draw[thick] (-.1,\y) --(.1,\y) node[left] {\small \y};
+​         ​       \draw[domain=-4.75:4.25,samples=200,very thick,<->] plot
+({\x},{(\x-2)^2*(\x+4)/8});
+​         ​       \node[thick] at (5,3.25) {$y=f(x)$};
+​         \end{tikzpicture}
+
+
+\begin{parts}
+\part[2] \textbf{(Choose all that apply)} For which $x$-value(s) is $f'(x)=0$?
+\begin{itemize}[label={}]
+\item \choosemany $x=-4$
+\item \choosemany $x=-2$
+\item \choosemany $x=2$
+\item \choosemany $x=4$
+\end{itemize}
+
+\vfill
+
+\part[2]\textbf{(Multiple Choice-Choose one)} Is $f'(-3)$ positive, negative, or zero?
+\begin{itemize}[label={}]
+\item \chooseone positive
+\item \chooseone negative
+\item \chooseone zero
+\end{itemize}
+\vfill
+
+
+\part[2]\textbf{(Multiple Choice-Choose one)} Is $f'(1)$ positive, negative, or zero?
+
+\begin{itemize}[label={}]
+\item \chooseone positive
+\item \chooseone negative
+\item \chooseone zero
+\end{itemize}
+
+\end{parts}
+\vfill
+
+\end{questions}
+
+\end{document}

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm2-PracticeA.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm2-PracticeA.tex
@@ -1,0 +1,324 @@
+\documentclass[addpoints,12pt]{exam}
+\newcommand{\ds}{\displaystyle}
+\usepackage[margin=0.8in]{geometry}
+\usepackage{subcaption}
+\usepackage{tikz}
+\usepackage{amssymb,amsmath,graphicx,wrapfig,verbatim,wasysym, enumitem,psfragx,color}
+\usepackage{multicol}
+
+%\usepackage{fancyhdr}
+%\setlength{\headheight}{13.6pt}
+%\pagestyle{fancy}
+%\lhead{Math 222}
+%\chead{ Midterm 1 }
+%\rhead{Spring 2022}
+
+\def\FillInBlank{\rule{3truein} {.01truein}}
+
+
+% Choose one option (bubbles)
+\newcommand{\chooseone}{{\Large$\Circle$\ \ }}
+
+
+\newcommand{\myleft}{\makebox[.4\textwidth]{First Name:\enspace\hrulefill}}
+\newcommand{\myright}{\makebox[.4\textwidth]{Last Name:\enspace\hrulefill}}
+\header{\oddeven{\myleft}{}}
+    {}
+    {\oddeven{\myright}{}}
+
+\footrule
+
+\footer{Math 211}
+     {Midterm 2 - Practice Exam}
+     {Page \thepage\ of \numpages}
+
+\begin{document}
+
+\begin{questions}
+
+
+\question Are each of the following true or false statements? Fill in the bubble next to the
+correct answer. Justification is not necessary.
+
+
+Reminder: Elasticity $=E(p)=\dfrac{-pD'(p)}{D(p)}$
+
+\begin{parts}
+
+\part[2] Suppose the demand function of a commodity is $D(p)=20-p$. If the current price is
+$p=5$, the demand is elastic.
+
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+
+
+
+\part[2] The value of $\$1000$ deposited in a bank at $12\%$ interest compounded quarterly for
+15 years is $1000(1.03)^{15}$ dollars.
+
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+
+
+
+%\part[2] For $y=5x^2$, the differential $dy$ at $x=2$ and $dx=0.3$ is $dy=6$.
+%\begin{itemize}[label={}]
+%\item \chooseone True
+%\item \chooseone False
+%\end{itemize}
+
+%\vfill
+
+
+\part[2] The function $f(x)=x^2-4x$ has an absolute minimum value of $-3$ on the interval
+$[3,6]$.
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+
+
+
+\vfill
+
+\end{parts}
+
+\newpage
+
+\question Use the given graph of the function $f$ to answer the following questions. Fill in the
+bubble next to the correct answer. Justification is not necessary.
+
+\begin{tikzpicture}[scale=.8]
+\draw[gray!40] (-5, -5) grid[step=1] (5, 5);
+\draw[<->,thick,black] (-6,0)--(6,0) node[right]{$x$};
+\draw[<->, thick,black] (0,-6)--(0,6) node[above]{$y$};
+\foreach \x in {-5,-4,...,5}
+\draw[thick] (\x,-.1) --(\x,.1) node[below]{\x};
+\foreach \y in {-5,-4,...,5}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] {\y};
+\draw[domain=-4.5:-1,samples=100, thick,<-] plot ({\x},{2*(\x+1)+2});
+\draw[domain=-1:1,samples=100, thick,-] plot ({\x},{-3*(\x+1)+2});
+\draw[domain=1:5,samples=100,thick,->] plot ({\x},{(\x/2+0.5});
+\draw[fill=black] (3,4) circle[radius=0.25em];
+\draw[fill=black] (1,-4) circle[radius=0.25em];
+\draw[fill=white,thick] (3,2) circle[radius=0.25em];
+\draw[fill=white,thick] (1,1) circle[radius=0.25em];
+\end{tikzpicture}
+
+\begin{parts}
+\part[1] The function is not differentiable at $x = -2.$
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\part[1] The function is not differentiable at $x = -1.$
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\part[1] The function is not differentiable at $x = 0.$
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\part[1] The function is not differentiable at $x = 1.$
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\part[1] The function is not differentiable at $x = 3.$
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\part[2] The given function is
+\begin{itemize}[label={}]
+\item \chooseone differentiable
+\item \chooseone nondifferentiable
+\item \chooseone neither
+\end{itemize}
+
+\end{parts}
+
+\newpage
+
+
+\question
+ Let $f(x)$ be a continuous function with derivative $\ds f'(x)=(x-2)^2(x+3)(x-5)$.
+\begin{parts}
+
+\part[3] Give all critical numbers for $f(x)$.
+
+
+\vspace{1.5in}
+
+
+\part[7] Using a sign chart, find the intervals of increasing and decreasing for $f(x)$. Write your
+answers using interval notation.
+
+\vspace{4in}
+
+
+\part[3] Classify each critical number as a relative minimum, relative maximum, or neither.
+
+\end{parts}
+
+\newpage
+
+
+\question[10] On the axes below,
+draw the graph of a continuous function $f(x)$ that satisfies the following:\smallskip
+
+​      $f(0)=5$\smallskip
+​
+​      $f'(0)=0$ \smallskip
+​
+​      $f'(x)>0$ on $(-\infty, 0)$\smallskip
+​
+​      $f'(x)<0$ on $(0,\infty)$\smallskip
+​
+​
+​      $f''(x)<0$ on $(-\infty, 2)$ \smallskip
+​
+​      $f''(x)>0$ on $(2,\infty)$\smallskip
+
+$\ds\lim_{x\to\infty}f(x)=1$
+
+
+​      \begin{tikzpicture}[scale=1]
+​      \draw[gray!60] (-7, -7) grid[step=1] (7, 7);
+​      \draw[<->, thick,black] (-8,0)--(8,0) node[right]{$x$};
+​      \draw[<->, thick,black] (0,-8)--(0,8) node[above]{$y$};
+​      \foreach \x in {-7,-6,...,7}
+​      \draw[thick] (\x,-.1) --(\x,.1)node[below]{\x};
+​      \foreach \y in {-7,-6,...,7}
+​      \draw[thick] (-.1,\y) --(.1,\y)node[left]{\y};
+​      \end{tikzpicture}
+​
+​
+
+\newpage
+
+\question[12]
+​       Farmer Stan is building a rectangular cattle pen to be enclosed by a fence and divided
+into three equal parts by two
+
+​      additional fences parallel to one of the sides (see picture below). If he has 200 meters of
+fencing available to use, what dimensions for the outer rectangle (i.e., what values for $x$ and
+$y$) will create the largest possible total area? Justify that your solution is optimal. Show all
+work.
+
+\bigskip
+
+​       \begin{figure}[h]
+​       ​       \begin{center}
+​       ​       ​       \begin{tikzpicture}
+​       ​       ​       ​       \draw[thick] (0,0) -- (6,0)--(6,4)--(0,4)--(0,0);
+​       ​       ​       ​       \draw[thick] (2,0) -- (2,4);
+​       ​       ​       ​       \draw[thick] (4,0) --(4,4);
+   \draw (0,4.2)--(6,4.2);
+   \draw (0,4.1)--(0,4.3);
+   \draw (6,4.1)--(6,4.3);
+   \draw (6.2,0)--(6.2,4);
+   \draw (6.1,0)--(6.3,0);
+   \draw (6.1,4)--(6.3,4);
+\draw (3,4.2) node[inner sep=2pt,fill=white] {$x$};
+\draw (6.2,2) node[inner sep=2pt,fill=white] {$y$};
+​       ​       ​       ​
+​       ​       ​       ​
+​       ​       ​       \end{tikzpicture}
+​       ​       \end{center}
+​       ​       %\caption{Useful figure for Problem 4}
+​       \end{figure}
+
+\newpage
+
+\question[10] Find the intervals of concavity and inflection points ($x$ values only) of\\
+$f(x)=\frac{1}{2}{x}^{4}-5{x}^{3}+12{x}^{2}+17x+89$. Give the intervals of concavity using
+interval notation. Show all work.
+
+
+\newpage
+
+
+
+
+\question[12] An Etsy necklace maker finds that when they price their necklaces at $\$20 $, they
+sell $100$ necklaces in a month. They determine that for each $\$1 $ price increase, they will
+sell 4 fewer necklaces per month. If each necklace costs $\$5$ to produce, what price should
+they charge to maximize profit? Justify your solution is optimal.
+
+\newpage
+
+
+
+
+\question
+
+
+\begin{parts}
+
+\part[6] After $t$ days of advertisements for a new restaurant, the proportions of shoppers in a
+town who have seen the ads is $1-e^{-0.04t}.$ How long must the ads run to reach 90\% of the
+shoppers? You do not need to simplify your answer.
+%4.2
+
+
+\vfill
+
+\part[6] Find $\dfrac{d}{dt}\ln(f(t))$ (i.e. the relative rate of change) of $f(t)=t^2+1$ at $t=2$.
+
+\vfill
+
+\part[6] A car worth \$15,000 depreciates in value by 15\% each year. How much is it worth after
+5 years? You do not need to simplify your answer.
+%4.1
+
+\vfill
+
+
+\end{parts}
+
+\newpage
+
+\question Compute the following derivatives.
+
+\begin{parts}
+
+\part[6] Find $f'(x)$ if $f(x) = \ln(x) \sqrt{x}.$ You do not need to simplify your final answer.
+
+\vfill
+
+\part[6] Find $g''(x)$ if $g(x)=e^{x^3}$. You do not need to simplify your final answer.
+
+\vfill
+
+\end{parts}
+
+
+
+
+\newpage
+
+
+
+
+\end{questions}
+
+\end{document}

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm2-PracticeB.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm2-PracticeB.tex
@@ -1,0 +1,326 @@
+\documentclass[addpoints,12pt]{exam}
+\newcommand{\ds}{\displaystyle}
+\usepackage[margin=0.8in]{geometry}
+\usepackage{subcaption}
+\usepackage{tikz}
+\usepackage{amssymb,amsmath,graphicx,wrapfig,verbatim,wasysym, enumitem,psfragx,color}
+\usepackage{multicol}
+
+%\usepackage{fancyhdr}
+%\setlength{\headheight}{13.6pt}
+%\pagestyle{fancy}
+%\lhead{Math 222}
+%\chead{ Midterm 1 }
+%\rhead{Spring 2022}
+
+\def\FillInBlank{\rule{3truein} {.01truein}}
+
+
+
+
+% Choose one option (bubbles)
+\newcommand{\chooseone}{{\Large$\Circle$\ \ }}
+% Choose multiple options (squares)
+\newcommand{\choosemany}{{\Large$\Square$\ \ }}
+
+
+\newcommand{\myleft}{\makebox[.4\textwidth]{First Name:\enspace\hrulefill}}
+\newcommand{\myright}{\makebox[.4\textwidth]{Last Name:\enspace\hrulefill}}
+\header{\oddeven{\myleft}{}}
+    {}
+    {\oddeven{\myright}{}}
+
+\footrule
+
+\footer{Math 211}
+     {Midterm 2 - Practice Exam}
+     {Page \thepage\ of \numpages}
+
+\begin{document}
+
+\begin{questions}
+
+
+\question Clearly mark the correct answer(s) for each of the following by completely filling in the
+appropriate bubble. \textbf{No justification is needed.}
+
+
+\begin{parts}
+
+
+\part[2] \textbf{(Multiple Choice-Choose one)} Suppose a rich aunt wants to buy you a car when
+you get your driver's license. How much money must she deposit in a trust fund paying $4\%$
+interest compounded quarterly at the time of your birth to yield $\$30,000$ on your 16th
+birthday?
+
+\begin{itemize} [label={}]
+\item \chooseone $30000(1.01)^{64}$\smallskip
+\item \chooseone $\dfrac{30000}{(1.01)^{64}}$\smallskip
+\item \chooseone $\dfrac{30000}{(1.04)^{16}}$\smallskip
+\item \chooseone $\dfrac{30000}{(1.01)^{16}}$\smallskip
+\item \chooseone None of the above.
+\end{itemize}
+
+\vfill
+
+
+
+
+\part[2] \textbf{(Multiple Choice-Choose one)} A store expects to sell 8000 bottles of perfume
+this year. The perfume costs the store owner $\$20$ per bottle, there is an ordering fee of
+$\$100$ per shipment, and the cost of storing the perfume is $\$10$ per bottle per year. The
+perfume is consumed at a constant rate throughout the year, and each shipment arrives just as
+the preceding shipment is used up. Which of the following is the correct expression for the
+
+yearly \textbf{storage costs} (in dollars) of the perfume with lot size $x$? (hint: average
+inventory is $x/2$).
+
+\begin{itemize}[label={}]
+\item \chooseone $5x$
+\item \chooseone $5x+100$
+\item \chooseone $25x+100$
+\item \chooseone $(20x+100)\dfrac{8000}{x}$
+\item \chooseone None of the above.
+\end{itemize}
+
+\vfill
+
+
+
+
+\part[2] \textbf{(Multiple Choice-Choose one)} Suppose monthly global data traffic is predicted to
+be
+$2.7e^{0.475x}$ petabytes, where $x$ is the number of years since 2016. Find the relative
+growth rate (per year) in 2026.
+\begin{itemize}[label={}]
+\item \chooseone $2.7\%$
+\item \chooseone $47.5\%$
+\item \chooseone $2.7e^{47.5}$
+\item \chooseone None of the above.
+\end{itemize}
+
+
+\vfill
+
+
+
+
+%\part[2] For $y=5x^2$, the differential $dy$ at $x=2$ and $dx=0.3$ is $dy=6$.
+%\begin{itemize}[label={}]
+%\item \chooseone True
+%\item \chooseone False
+%\end{itemize}
+
+%\vfill
+\newpage
+
+\part[2] \textbf{(Choose all that apply)} Given the graph of $y=f(x)$ below, where is $f(x)$
+nondifferentiable?
+\begin{itemize}[label={}]
+\item \choosemany $x=-1$
+
+\item \choosemany $x=0$
+\item \choosemany $x=1$
+\item \choosemany $x=2$
+\item \choosemany $x=3$
+\item \choosemany None of the above.
+\end{itemize}
+
+\begin{tikzpicture}[scale=.8]
+\draw[gray!40] (-5, -3) grid[step=1] (5, 5);
+\draw[<->,thick,black] (-6,0)--(6,0) node[right]{$x$};
+\draw[<->, thick,black] (0,-3.5)--(0,6) node[above]{$y$};
+\foreach \x in {-5,-4,...,5}
+\draw[thick] (\x,-.1) --(\x,.1) node[below]{\x};
+\foreach \y in {-3,-2,...,5}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] {\y};
+\draw[domain=1:4.5,samples=100, thick,->] plot ({\x},{-(\x+1)+6});
+\draw[domain=-1:1,samples=100, thick,-] plot ({\x},{3*\x+1});
+\draw[domain=-5:-1,samples=100,thick,<-] plot ({\x},{(\x/2+1.5});
+\draw[fill=black] (3,4) circle[radius=0.25em];
+\draw[fill=black] (-1,1) circle[radius=0.25em];
+\draw[fill=white,thick] (3,2) circle[radius=0.25em];
+\draw[fill=white,thick] (-1,-2) circle[radius=0.25em];
+\end{tikzpicture}
+
+
+
+
+\vfill
+
+
+
+
+\part[2] \textbf{(True/False)} $f(x)=e^{x^2-x}$ has a critical number at $x=0$.
+
+\begin{itemize}[label={}]
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+\part[2] \textbf{(True/False)} A Hyundai Sonata lists for $\$ 22,000$ and depreciates in value by
+$30\%$ each year. In 3 years, it will be worth $22,000(.3)^3$.
+
+\begin{itemize}[label={}]
+
+\item \chooseone True
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+
+\end{parts}
+
+\newpage
+
+\question For the demand function $D(p)=40-p$:
+\begin{parts}
+ \part[4] Find the elasticity of demand $E(p)$ and evaluate it at $p=10.$ Simplify your answer.
+
+ \vfill
+
+ \part[3] Is the demand elastic or inelastic at $p=10$? To increase revenue, should you increase
+or decrease the price?
+   \vfill
+
+  \part[3] Find the price at which the demand is unit-elastic.
+   \vfill
+
+\end{parts}
+
+\newpage
+
+
+\question
+Suppose $f(x)$ is a continuous function whose derivative is $f'(x)=x^{-1/3}(2-x)(x+4)^2$.
+\begin{parts}
+\part[4] What are the critical numbers of $f(x)$?
+\vspace{2in}
+\part[7] At what points, if any, does $f(x)$ assume relative maximum and minimum values?
+Fully justify your answer.
+\end{parts}
+
+\newpage
+
+
+\question[11] On the axes below,
+draw the graph of a function $f(x)$ which is continuous everywhere except $x=1$ that satisfies
+the following conditions:\\
+
+$f(0)=1$\\
+$f(x)$ has a vertical asymptote at $x=1$\\
+$f'(x)<0$ on $(4,\infty)$\\
+$f'(x)>0$ on $(-\infty, 1)\cup(1,4)$\\
+$f''(x)>0$ on $(-\infty, 1)$\\
+$f''(x)<0$ on $( 1,\infty)$
+
+
+​        \begin{tikzpicture}[scale=1]
+​        \draw[gray!60] (-7, -7) grid[step=1] (7, 7);
+​        \draw[<->, thick,black] (-8,0)--(8,0) node[right]{$x$};
+​        \draw[<->, thick,black] (0,-8)--(0,8) node[above]{$y$};
+​        \foreach \x in {-7,-6,...,7}
+​        \draw[thick] (\x,-.1) --(\x,.1)node[below]{\x};
+​        \foreach \y in {-7,-6,...,7}
+​        \draw[thick] (-.1,\y) --(.1,\y)node[left]{\y};
+​        \end{tikzpicture}
+​
+​
+
+\newpage
+
+\question[12]
+​        A rectangular sheep pen is to be enclosed by a wooden fence and divided into two
+equal parts by a chain link fence parallel to one of the sides. The wooden fencing will cost $\$4$
+per foot, while the chain link will cost $\$ 2 $ per foot. With $\$400$ to spend, what dimensions
+for the outer rectangle will create the largest total area? Justify your solution is optimal.
+
+\bigskip
+
+​        \begin{figure}[h]
+​        ​       \begin{center}
+​        ​       ​       \begin{tikzpicture}
+​        ​       ​       ​       \draw[thick] (0,0) -- (6,0)--(6,4)--(0,4)--(0,0);
+​        ​       ​       ​       \draw[thick, dashdotdotted] (3,0) --(3,4);
+    \draw (0,4.2)--(6,4.2);
+
+   \draw (0,4.1)--(0,4.3);
+   \draw (6,4.1)--(6,4.3);
+   \draw (6.2,0)--(6.2,4);
+   \draw (6.1,0)--(6.3,0);
+   \draw (6.1,4)--(6.3,4);
+\draw (3,4.2) node[inner sep=2pt,fill=white] {$x$};
+\draw (6.2,2) node[inner sep=2pt,fill=white] {$y$};
+​       ​       ​       ​
+​       ​       ​       ​
+​       ​       ​       \end{tikzpicture}
+​       ​       \end{center}
+​       ​       %\caption{Useful figure for Problem 4}
+​       \end{figure}
+
+\newpage
+
+\question For $f(x)=x^4-4x^3+10 $:
+
+\begin{parts}
+
+\part[5] Find the intervals of increasing/decreasing. Give your answers using interval notation.
+Show all work.
+
+\vfill
+\part[5] Find the intervals of concave up/concave down. Give your answers using interval
+notation. Show all work.
+\vfill
+\end{parts}
+
+\newpage
+
+
+
+
+\question[12] A bus company will rent a bus that holds 50 people to groups of 30 people or
+more. If a group contains exactly 30 people, each person pays $\$80$. In large groups,
+everybody's fare is reduced by $\$2$ for each person in excess of 30. Determine the size of the
+group for which the bus company's revenue will be greatest. Justify why your solution is optimal.
+
+
+
+
+\newpage
+
+\question[10] Find the absolute maximum and absolute minimum of $g(x)=6x^2-x^3-6$ on
+$[-1,3]$.
+
+
+\vfill
+
+
+
+
+\newpage
+
+\question
+
+\begin{parts}
+
+\part[6] Find $f'(x)$ if $f(x) = \ln(x^2+2x)$. You do not need to simplify your final answer.
+
+\vfill
+
+\part[6] Find $g'(x)$ if $g(x)=e^{x^2+4x}$. You do not need to simplify your final answer.
+
+\vfill
+
+\end{parts}
+
+
+
+
+\newpage
+
+\end{questions}
+
+\end{document}

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm2.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm2.tex
@@ -1,0 +1,362 @@
+\documentclass[addpoints,12pt]{exam}
+\newcommand{\ds}{\displaystyle}
+\usepackage[margin=0.8in]{geometry}
+\usepackage{subcaption}
+\usepackage{tikz}
+\usepackage{amssymb,amsmath,graphicx,wrapfig,verbatim,wasysym, enumitem,psfragx,color}
+\usepackage{multicol}
+
+
+\usepackage{pgf,tikz,pgfplots}
+\usepackage{stmaryrd}
+\usetikzlibrary{arrows, shapes.geometric, matrix, turtle, plotmarks}
+
+%\usepackage{fancyhdr}
+%\setlength{\headheight}{13.6pt}
+%\pagestyle{fancy}
+%\lhead{Math 222}
+%\chead{ Midterm 1 }
+%\rhead{Spring 2022}
+
+\def\FillInBlank{\rule{3truein} {.01truein}}
+
+% Choose one option (bubbles)
+\newcommand{\chooseone}{{\Large$\Circle$\ \ }}
+% Choose multiple options (squares)
+\newcommand{\choosemany}{{\Large$\Square$\ \ }}
+
+
+\newcommand{\myleft}{\makebox[.4\textwidth]{First Name:\enspace\hrulefill}}
+\newcommand{\myright}{\makebox[.4\textwidth]{Last Name:\enspace\hrulefill}}
+\header{\oddeven{\myleft}{}}
+    {}
+    {\oddeven{\myright}{}}
+
+\footrule
+
+\footer{Math 211}
+     {Midterm 2 - Fall 2024}
+     {Page \thepage\ of \numpages}
+
+\begin{document}
+
+\begin{questions}
+
+\question Clearly mark the correct answer(s) for each of the following by completely filling in the
+appropriate bubble. \textbf{No justification is needed.}
+
+
+
+
+\begin{parts}
+
+
+
+
+\part[2] \textbf{(Multiple Choice-Choose one)} Which of the following is equal to
+
+$\ln(3x^4)- 3\ln(x)$?
+
+\begin{itemize}[label={}]
+\item \chooseone $\ln(x^{9})$\medskip
+\item \chooseone $\ln(3)+\ln(x)$\medskip
+\item \chooseone $\ln(3)\ln(x)$\medskip
+\item \chooseone None of the above.
+\end{itemize}
+
+\vfill
+
+
+\part[2] \textbf{(Multiple Choice-Choose one)} What are the vertical asymptotes of
+
+$f(x)=\dfrac{x+3}{x^2+2x-8}$?
+     \vspace{0.15in}
+\begin{itemize}[label={}]
+\item \chooseone $x=-4$ and $x=2$ \medskip
+\item \chooseone $x=-4$, $x=-3$, and $x=2$\medskip
+\item \chooseone $x=-4$, $x=-3$, $x=1$, and $x=2$\medskip
+\item \chooseone None of the above.
+\end{itemize}
+
+
+\vfill
+
+
+
+
+\part[2] \textbf{(True/False)} If $g(x)$ has an absolute maximum, then $g(x)$ must have an
+absolute minimum.
+
+\begin{itemize}[label={}]
+\item \chooseone True\medskip
+\item \chooseone False
+\end{itemize}
+
+\vfill
+
+\part[2] If the elasticity of demand is $\dfrac{4}{3}$ for a given price, is the demand elastic or
+inelastic, and should we raise or lower the price to increase revenue?
+\begin{itemize}[label={}]
+\item \chooseone Demand is \textbf{elastic}, and we should \textbf{raise} the price to increase
+revenue.\medskip
+\item \chooseone Demand is \textbf{elastic}, and we should \textbf{lower} the price to increase
+revenue.\medskip
+\item \chooseone Demand is \textbf{inelastic}, and we should \textbf{raise} the price to increase
+revenue.\medskip
+\item \chooseone Demand is \textbf{inelastic}, and we should \textbf{lower} the price to increase
+revenue.\medskip
+\end{itemize}
+
+\newpage
+
+
+
+
+\part[2] A gift store expects to sell 500 candles this year. The candles costs the store owner
+$\$4$ per candle, there is an ordering fee of $\$20$ per shipment, and the cost of storing the
+candles is $\$2$ per candle per year. The candle inventory is consumed at a constant rate
+throughout the year, and each shipment arrives just as the preceding shipment is used up.
+Which of the following is the correct expression for the yearly \textbf{total costs} (storage costs
+plus reorder costs) in dollars of the candles with lot size $x$? (Hint: The average inventory size
+is half the lot size.)
+
+\begin{itemize}[label={}]
+\item \chooseone $(4x+20) \left(\dfrac{500}{x}\right)$\medskip
+\item \chooseone $x+(4x+20)\left(\dfrac{500}{x}\right)$\medskip
+\item \chooseone $4x+20$\medskip
+\item \chooseone $500+(4x+20) \left(\dfrac{500}{x}\right)$
+\end{itemize}
+
+\vfill
+
+\part[2] \textbf{(Multiple Choice-Choose one)} For $g(x)=\ln(e^x - 4x)$, which of the following is
+$g'(0)$?
+      \vspace{0.15in}
+\begin{itemize}[label={}]
+\item \chooseone $g'(0)=-4$\medskip
+\item \chooseone $g'(0)=-3$\medskip
+\item \chooseone $g'(0)=0$ \medskip
+\item \chooseone $g'(0)=1$ \medskip
+\item \chooseone None of the above.
+\end{itemize}
+
+\vfill
+
+
+\part[2] \textbf{(Select all that apply)} Given the graph of $y=f(x)$ below, where is $f(x)$
+nondifferentiable?
+
+\begin{minipage}{.4\textwidth}
+\begin{itemize}[label={}]
+\item \choosemany $x=-3$\medskip
+\item \choosemany $x=-1$\medskip
+\item \choosemany $x=0$\medskip
+
+\item \choosemany $x=1$\medskip
+\item \choosemany None of the above.
+\end{itemize}
+\end{minipage}
+\begin{minipage}{.5\textwidth}
+\begin{tikzpicture}[scale=.8]
+\draw[gray!40] (-5, 0) grid[step=1] (5, 6);
+\draw[<->,thick,black] (-5.5,0)--(5.5,0) node[right]{$x$};
+\draw[->, thick,black] (0,0)--(0,6.5) node[above]{$y$};
+\foreach \x in {-5,-4,...,5}
+\draw[thick] (\x,-.1) --(\x,.1) node[below]{\x};
+\foreach \y in {0,1,...,6}
+\draw[thick] (-.1,\y) --(.1,\y) node[left] {\y};
+\draw[domain=-5:-3,samples=100, very thick,<-] plot ({\x},{2*\x+11});
+\draw[domain=-3:1,samples=100,very thick,-] plot ({\x},{(\x+1)^2+1});
+\draw[domain=1:4,samples=100,very thick,->] plot ({\x},{-1/2*(\x-1)+2});
+\draw[fill=white,thick] (1,5) circle[radius=0.25em];
+\draw[fill=black] (1,2) circle[radius=0.25em];
+\node at (4.8,1.2) {$y=f(x)$};
+\end{tikzpicture}
+
+\end{minipage}
+\vfill
+
+\end{parts}
+
+\newpage
+
+
+
+
+\question Suppose $f(x)$ is a continuous function whose derivative is
+$f'(x)=-4(x-1)(x-2)^3(x+3)^2$.
+\begin{parts}
+\part[3] What are the critical numbers of $f(x)$?
+\vspace{1in}
+\part[5] Using a sign chart, find the intervals of increasing and decreasing for $f(x)$. Write your
+answers using interval notation.
+
+\vfill
+
+\part[3] Classify each critical number as the location of a relative minimum, relative maximum, or
+neither. No justification is needed.
+
+\vspace{1.5in}
+\end{parts}
+
+
+\newpage
+
+
+
+
+\question[11] On the axes below,
+draw the graph of a function $f(x)$ which is \textbf{continuous} everywhere that satisfies all the
+following conditions:\\
+
+$f(-2)=0$ and $f(0)=3$. \medskip
+
+$f(x)$ is not differentiable at $x=-2$. \medskip
+
+$f'(x)>0$ on $(-2,0)$. \medskip
+
+$f'(x)<0$ on $(-\infty, -2)\cup(0,\infty)$. \medskip
+
+$f''(x)<0$ on $( -\infty,-2)\cup(-2,2)$. \medskip
+
+$f''(x)>0$ on $( 2,\infty)$. \medskip
+
+$\displaystyle \lim_{x\to \infty}f(x)=-1$.
+
+
+\begin{center}
+​      \begin{tikzpicture}[scale=1.2]
+​      \draw[gray!60] (-6, -6) grid[step=1] (6, 6);
+​      \draw[<->, thick,black] (-6.5,0)--(6.5,0) node[right]{$x$};
+​      \draw[<->, thick,black] (0,-6.5)--(0,6.5) node[above]{$y$};
+​      \foreach \x in {-6,-5,...,6}
+​      \draw[thick] (\x,-.1) --(\x,.1)node[below]{\x};
+​      \foreach \y in {-6,-5,...,6}
+​      \draw[thick] (-.1,\y) --(.1,\y)node[left]{\y};
+​      \end{tikzpicture}
+\end{center}​
+
+
+
+
+\newpage
+
+\question[11] A woodworker finds that when they price their cutting boards at $\$50 $, they sell
+$30$ cutting boards in a month. They determine that for each $\$1 $ price discount, they will sell
+3 more cutting boards per month. If each cutting board costs $\$20$ to produce, find the price of
+the cutting boards which will maximize their profit AND the number of cutting boards sold. Write
+each answer clearly with units, and justify your solution gives the maximum profit. Show all
+work.
+
+
+
+
+\newpage
+
+\question
+
+\begin{parts}
+
+\part[6] After $t$ weeks of practice, a typing student can type $120(1-e^{-0.3t})$ words per
+minute. How long will it take for the student to be able to type 100 words per minute? Show all
+work. You do not need to simplify your final answer, but include units.
+
+\vfill
+
+
+
+
+\part[6] A rich aunt wants to give her nephew $\$45,000$ when he turns 18. How much money
+must she deposit in a trust fund paying $8\%$ compounded quarterly at the time of the
+nephew's birth to yield $\$45,000$ when he turns 18? Show all work. You do not need to
+simplify your answer.
+
+\vfill
+
+\end{parts}
+
+
+
+
+\newpage
+
+\question[8]
+Find the inflection point(s) ($x$-value(s) only) and intervals of concavity for
+
+$f(x)=9x^2-x^3+10x+12$. Give the intervals of concavity using interval notation. Show all work.
+
+\newpage
+
+
+\question[11] A dog daycare owner wants to build a rectangular fenced area along the side of
+the daycare building, split into two equal parts by a fence parallel to one of its sides (see picture
+below, the dashed lines denote fencing). If the side along the building needs no fence,
+with 300 meters of fencing available to use, what dimensions for the outer rectangle will create
+the largest total area? Show all work, including justification that your solution is optimal.
+
+\begin{figure}[h]
+​       ​       \begin{center}
+​       ​       ​        \begin{tikzpicture}
+​       ​       ​        ​       \draw[thick,dashed] (0,0) -- (6,0)--(6,4)--(0,4)--(0,0);
+​       ​       ​        ​       \draw[thick,dashed] (3,0) --(3,4);
+   \draw[ultra thick] (-2,0)--(8,0);
+  % \foreach \x in {-2,-1,...,8}
+   %\draw[thick] (\x,0) --(\x-0.25,-0.25);
+\draw (3, -0.5) node {Building};
+  \draw (0,4.2)--(6,4.2);
+   \draw (0,4.1)--(0,4.3);
+   \draw (6,4.1)--(6,4.3);
+   \draw (6.2,0)--(6.2,4);
+   \draw (6.1,0)--(6.3,0);
+   \draw (6.1,4)--(6.3,4);
+\draw (3,4.2) node[inner sep=2pt,fill=white] {$x$};
+\draw (6.21,2) node[inner sep=2pt,fill=white] {$y$};
+​       ​       ​        ​
+​       ​       ​        ​
+​       ​       ​        \end{tikzpicture}
+​       ​       \end{center}
+​       ​       %\caption{Useful figure for Problem 4}
+​       \end{figure}
+
+\newpage
+
+
+\question Compute the following:
+
+\begin{parts}
+
+\part[5] Find $f'(x)$ if $f(x) = x^2\ln(4x).$ You do not need to simplify your final answer.
+
+\vfill
+
+\part[6] Find $g''(x)$ if $\displaystyle g(x)=e^{x^2+2x}$. You do not need to simplify your final
+answer.
+
+\vfill
+
+\end{parts}
+
+\newpage
+
+\question
+
+\begin{parts}
+\part[6] For the demand function $D(p)=60-p^2$, find the elasticity of demand $E(p)$ and
+evaluate it at $p=5.$ Show all work. You do not need to simplify your final numerical answer.
+
+ \vfill
+
+
+
+
+\part[5] Find the relative rate of change of $f(t)=t^3+2t$ at $t=3$. Show all work. You do not
+need to simplify your final numerical answer.
+
+
+\vfill
+\end{parts}
+
+
+\end{questions}
+
+\end{document}


### PR DESCRIPTION
## Summary
- drop the leftover plain-text titles that preceded `\documentclass` in every Math 211 Fall 2024 exam and practice TeX file so the documents start with their preamble

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e78983c3cc8328820cc36864e42138