### PR TITLE
Remove zero-width spaces from fall 2024 exam TeX files

### DIFF
--- a/source/ch-2024-fall-exams/Math211Fa24-FinalExam-PracticeA.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-FinalExam-PracticeA.tex
@@ -174,14 +174,14 @@ Calculate each integral. You do not need to simplify your answer. Show all work.
 \vfill
 
 \end{parts}
-​
+
 
 \newpage
 
 \question[9] A company's marginal cost function is $MC(x)=2e^{-x}$, where $x$ is the number of
 units. Find the total cost of producing the first hundred units ($x=0$ to $x=100$). Show all work.
 You do not need to simplify your final numerical answer.
-​
+
 
 \newpage
 
@@ -284,13 +284,13 @@ Use the graph of $y=f'(x)$ to answer the following. {Briefly justify your answer
 
 Again, \textbf{this is the graph of the derivative of $f(x)$.}
 \begin{parts}
-​       \part[2] On which interval(s) is $f(x)$ increasing? Briefly justify your answer.
+       \part[2] On which interval(s) is $f(x)$ increasing? Briefly justify your answer.
  \vfill
 
-​         \part[2] Is $f(x)$ concave up or concave down at $x=-4$? Briefly justify your answer.
+         \part[2] Is $f(x)$ concave up or concave down at $x=-4$? Briefly justify your answer.
  \vfill
 
-​       \part[2] What is $\displaystyle \lim_{h\to0}\frac{f(3+h)-f(3)}{h}$? Briefly justify your
+       \part[2] What is $\displaystyle \lim_{h\to0}\frac{f(3+h)-f(3)}{h}$? Briefly justify your
 answer.
  \vfill
 

--- a/source/ch-2024-fall-exams/Math211Fa24-FinalExam-PracticeB.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-FinalExam-PracticeB.tex
@@ -217,7 +217,7 @@ Calculate each integral. You do not need to simplify your answer. Show all work.
 \vfill
 
 \end{parts}
-​
+
 
 \newpage
 
@@ -228,7 +228,7 @@ Calculate each integral. You do not need to simplify your answer. Show all work.
 9:00am, visitors will be entering the fair at the rate of $N'(t)=16-t^2$ hundred people per hour.
 Find the total number of people who will enter the fair between 11:00am and 2:00pm. You do not
 need to simplify the final numerical answer, but provide units.
-​
+
 
 \newpage
 
@@ -283,20 +283,20 @@ Show all work.
 
 \question Given the following information about two functions, $g(x)$ and $f(x)$:
 \begin{itemize}
-​       \item[] $f(3)=4$ \quad $f'(3)=-7$
-​       \item[] $g(3)=2$ \quad $g'(3)=5$
-​       \item[] $f(6)=8$ \quad $f'(6)=3$
+       \item[] $f(3)=4$ \quad $f'(3)=-7$
+       \item[] $g(3)=2$ \quad $g'(3)=5$
+       \item[] $f(6)=8$ \quad $f'(6)=3$
 \item[] $g(6)=9$\quad $g'(6)=10$
-​
+
 \end{itemize}
 Compute each of the following. Simplify your answers.
 \begin{parts}
 
-​      \part[2] $h'(3)$ if $h(x)=f(x)g(x)$.\vfill
-​      \part[2] $h'(6)$ if $h(x)=\dfrac{3f(x)}{4}$.\vfill
-​      \part[2] $\displaystyle \lim_{h\to 0}\dfrac{f(h+3)-f(3)}{h}$.\vfill
+      \part[2] $h'(3)$ if $h(x)=f(x)g(x)$.\vfill
+      \part[2] $h'(6)$ if $h(x)=\dfrac{3f(x)}{4}$.\vfill
+      \part[2] $\displaystyle \lim_{h\to 0}\dfrac{f(h+3)-f(3)}{h}$.\vfill
      \part[2] The average value of $g'(x)$ on $[3,6]$.\vfill
-​      \part[2] The relative rate of change of $g(x)$ at $x=3$.\vfill
+      \part[2] The relative rate of change of $g(x)$ at $x=3$.\vfill
 \end{parts}
 
 

--- a/source/ch-2024-fall-exams/Math211Fa24-FinalExam.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-FinalExam.tex
@@ -335,14 +335,14 @@ Use the graph of $y=f'(x)$ to answer the following. No justification is required
 Again, \textbf{this is the graph of the derivative of $f(x)$.}
 
 \begin{parts}
-​        \part[2] On which interval(s) is $f(x)$ decreasing?
+        \part[2] On which interval(s) is $f(x)$ decreasing?
  \vfill
 \part[2] At which $x$-value(s) does $f(x)$ have a horizontal tangent line?
 \vfill
 
-​         \part[2] What is $\displaystyle \lim_{h\to0}\frac{f(h)-f(0)}{h}$?
+         \part[2] What is $\displaystyle \lim_{h\to0}\frac{f(h)-f(0)}{h}$?
   \vfill
-​        \part[2] Is $f(x)$ concave up or concave down at $x=2$?
+        \part[2] Is $f(x)$ concave up or concave down at $x=2$?
  \vfill
 
 

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm1-PracticeA.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm1-PracticeA.tex
@@ -223,19 +223,19 @@ do not need to simplify your final numerical answer.
 
 
 \question Consider the function $y=f(x)$ below. Answer the following questions.
-​
-​        \begin{tikzpicture}[scale=.99]
-​        ​        \draw[gray!60] (-5, -5) grid[step=1] (5, 5);
-​        ​        \draw[<->,thick,black] (-5,0)--(5,0) node[right]{$x$};
-​        ​        \draw[<->, thick,black] (0,-5)--(0,5) node[above]{$y$};
-​        ​        \foreach \x in {-5,-4,...,5}
-​        ​        \draw[thick] (\x,-.1) --(\x,.1) node[below] {\small \x};
-​        ​        \foreach \y in {-5,-4,...,5}
-​        ​        \draw[thick] (-.1,\y) --(.1,\y) node[left] {\small \y};
-​        ​        \draw[domain=-3.5:4.25,samples=200,thick,<->] plot
+
+        \begin{tikzpicture}[scale=.99]
+                \draw[gray!60] (-5, -5) grid[step=1] (5, 5);
+                \draw[<->,thick,black] (-5,0)--(5,0) node[right]{$x$};
+                \draw[<->, thick,black] (0,-5)--(0,5) node[above]{$y$};
+                \foreach \x in {-5,-4,...,5}
+                \draw[thick] (\x,-.1) --(\x,.1) node[below] {\small \x};
+                \foreach \y in {-5,-4,...,5}
+                \draw[thick] (-.1,\y) --(.1,\y) node[left] {\small \y};
+                \draw[domain=-3.5:4.25,samples=200,thick,<->] plot
 ({\x},{(3*\x*\x*\x*\x-8*\x*\x*\x-30*\x*\x+72*\x)/50});
-​        ​        \node at (4,2.7) {$y=f(x)$};
-​        \end{tikzpicture}
+                \node at (4,2.7) {$y=f(x)$};
+        \end{tikzpicture}
 
 
 \begin{parts}

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm1-PracticeB.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm1-PracticeB.tex
@@ -283,18 +283,18 @@ applicable.
 
 \begin{parts}
 \part[2] $\ds \lim_{x\to 3^-}f(x)=$
-​        \vspace{0.5in}
+        \vspace{0.5in}
 
 \part[2]$\ds \lim_{x\to 3^+}f(x)=$
-​       ​        \vspace{0.5in}
+               \vspace{0.5in}
 
 
 \part[2]$\ds \lim_{x\to 3}f(x)=$
-​       \vspace{0.5in}
+       \vspace{0.5in}
 
 
 \part[2]$\ds \lim_{x\to 0}f(x)=$
-​       \vspace{0.5in}
+       \vspace{0.5in}
 
 
 \part[2]$\ds \lim_{x\to 2^-}f(x)=$
@@ -321,30 +321,30 @@ applicable.
 \question Suppose the graph below is $f'(x)$. Assume each tick mark is 1 unit.
 
 \begin{tikzpicture}[scale=1.5]
-​        \draw[<->,thick] (-2.2,0) -- (3.5,0) node[right] {$x$};
-​        \draw[<->,thick] (0,-2) -- (0,3.5) node[above] {$y$};
-​        \foreach \x in {-4,-3,...,6}
-​        \draw[scale=0.5] (\x,-.2) --(\x,.2);
-​        \foreach \y in {-3,-2,...,6}
-​        \draw[scale=0.5] (-.2,\y) --(.2,\y);
-​        \draw[<->, scale=1,domain=-2.1:3.25,smooth,variable=\x,blue, thick] plot
+        \draw[<->,thick] (-2.2,0) -- (3.5,0) node[right] {$x$};
+        \draw[<->,thick] (0,-2) -- (0,3.5) node[above] {$y$};
+        \foreach \x in {-4,-3,...,6}
+        \draw[scale=0.5] (\x,-.2) --(\x,.2);
+        \foreach \y in {-3,-2,...,6}
+        \draw[scale=0.5] (-.2,\y) --(.2,\y);
+        \draw[<->, scale=1,domain=-2.1:3.25,smooth,variable=\x,blue, thick] plot
 ({\x},{-.25*\x*(\x-1.5)*(\x+2)*(\x-3)}) node[above]{$y=f'(x)$};
-​        \end{tikzpicture}
+        \end{tikzpicture}
 
-​       \begin{parts}
-​       ​      \part[2] At which $x$-values does $f(x)$ have a horizontal tangent line? Briefly
+       \begin{parts}
+             \part[2] At which $x$-values does $f(x)$ have a horizontal tangent line? Briefly
 explain your answer.
   \vspace{1.5in}
 
-​         ​      \part[2] On which intervals is $f(x)$ increasing? Briefly explain your answer.
+               \part[2] On which intervals is $f(x)$ increasing? Briefly explain your answer.
     \vspace{1.5in}
 
 
-​       ​      \part[2] On which intervals is $f(x)$ decreasing?Briefly explain your answer.
+             \part[2] On which intervals is $f(x)$ decreasing?Briefly explain your answer.
   \vspace{1.5in}
-​       \end{parts}
-​
-​
+       \end{parts}
+
+
 
 
 

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm1.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm1.tex
@@ -318,19 +318,19 @@ Find each limit. Show all work. Simplify your final answers.
 
 \question Consider the function $y=f(x)$ below. Clearly mark the correct answer(s) for each of
 the following by completely filling in the appropriate bubble. \textbf{No justification is needed.}
-​
-​         \begin{tikzpicture}[scale=.99]
-​         ​       \draw[gray!60] (-5, -5) grid[step=1] (5, 5);
-​         ​       \draw[<->,thick,black] (-5.3,0)--(5.3,0) node[right]{$x$};
-​         ​       \draw[<->, thick,black] (0,-5.3)--(0,5.3) node[above]{$y$};
-​         ​       \foreach \x in {-5,-4,...,5}
-​         ​       \draw[thick] (\x,-.1) --(\x,.1) node[below] {\small \x};
-​         ​       \foreach \y in {-5,-4,...,5}
-​         ​       \draw[thick] (-.1,\y) --(.1,\y) node[left] {\small \y};
-​         ​       \draw[domain=-4.75:4.25,samples=200,very thick,<->] plot
+
+         \begin{tikzpicture}[scale=.99]
+                \draw[gray!60] (-5, -5) grid[step=1] (5, 5);
+                \draw[<->,thick,black] (-5.3,0)--(5.3,0) node[right]{$x$};
+                \draw[<->, thick,black] (0,-5.3)--(0,5.3) node[above]{$y$};
+                \foreach \x in {-5,-4,...,5}
+                \draw[thick] (\x,-.1) --(\x,.1) node[below] {\small \x};
+                \foreach \y in {-5,-4,...,5}
+                \draw[thick] (-.1,\y) --(.1,\y) node[left] {\small \y};
+                \draw[domain=-4.75:4.25,samples=200,very thick,<->] plot
 ({\x},{(\x-2)^2*(\x+4)/8});
-​         ​       \node[thick] at (5,3.25) {$y=f(x)$};
-​         \end{tikzpicture}
+                \node[thick] at (5,3.25) {$y=f(x)$};
+         \end{tikzpicture}
 
 
 \begin{parts}

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm2-PracticeA.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm2-PracticeA.tex
@@ -185,53 +185,53 @@ answers using interval notation.
 \question[10] On the axes below,
 draw the graph of a continuous function $f(x)$ that satisfies the following:\smallskip
 
-​      $f(0)=5$\smallskip
-​
-​      $f'(0)=0$ \smallskip
-​
-​      $f'(x)>0$ on $(-\infty, 0)$\smallskip
-​
-​      $f'(x)<0$ on $(0,\infty)$\smallskip
-​
-​
-​      $f''(x)<0$ on $(-\infty, 2)$ \smallskip
-​
-​      $f''(x)>0$ on $(2,\infty)$\smallskip
+      $f(0)=5$\smallskip
+
+      $f'(0)=0$ \smallskip
+
+      $f'(x)>0$ on $(-\infty, 0)$\smallskip
+
+      $f'(x)<0$ on $(0,\infty)$\smallskip
+
+
+      $f''(x)<0$ on $(-\infty, 2)$ \smallskip
+
+      $f''(x)>0$ on $(2,\infty)$\smallskip
 
 $\ds\lim_{x\to\infty}f(x)=1$
 
 
-​      \begin{tikzpicture}[scale=1]
-​      \draw[gray!60] (-7, -7) grid[step=1] (7, 7);
-​      \draw[<->, thick,black] (-8,0)--(8,0) node[right]{$x$};
-​      \draw[<->, thick,black] (0,-8)--(0,8) node[above]{$y$};
-​      \foreach \x in {-7,-6,...,7}
-​      \draw[thick] (\x,-.1) --(\x,.1)node[below]{\x};
-​      \foreach \y in {-7,-6,...,7}
-​      \draw[thick] (-.1,\y) --(.1,\y)node[left]{\y};
-​      \end{tikzpicture}
-​
-​
+      \begin{tikzpicture}[scale=1]
+      \draw[gray!60] (-7, -7) grid[step=1] (7, 7);
+      \draw[<->, thick,black] (-8,0)--(8,0) node[right]{$x$};
+      \draw[<->, thick,black] (0,-8)--(0,8) node[above]{$y$};
+      \foreach \x in {-7,-6,...,7}
+      \draw[thick] (\x,-.1) --(\x,.1)node[below]{\x};
+      \foreach \y in {-7,-6,...,7}
+      \draw[thick] (-.1,\y) --(.1,\y)node[left]{\y};
+      \end{tikzpicture}
+
+
 
 \newpage
 
 \question[12]
-​       Farmer Stan is building a rectangular cattle pen to be enclosed by a fence and divided
+       Farmer Stan is building a rectangular cattle pen to be enclosed by a fence and divided
 into three equal parts by two
 
-​      additional fences parallel to one of the sides (see picture below). If he has 200 meters of
+      additional fences parallel to one of the sides (see picture below). If he has 200 meters of
 fencing available to use, what dimensions for the outer rectangle (i.e., what values for $x$ and
 $y$) will create the largest possible total area? Justify that your solution is optimal. Show all
 work.
 
 \bigskip
 
-​       \begin{figure}[h]
-​       ​       \begin{center}
-​       ​       ​       \begin{tikzpicture}
-​       ​       ​       ​       \draw[thick] (0,0) -- (6,0)--(6,4)--(0,4)--(0,0);
-​       ​       ​       ​       \draw[thick] (2,0) -- (2,4);
-​       ​       ​       ​       \draw[thick] (4,0) --(4,4);
+       \begin{figure}[h]
+              \begin{center}
+                     \begin{tikzpicture}
+                            \draw[thick] (0,0) -- (6,0)--(6,4)--(0,4)--(0,0);
+                            \draw[thick] (2,0) -- (2,4);
+                            \draw[thick] (4,0) --(4,4);
    \draw (0,4.2)--(6,4.2);
    \draw (0,4.1)--(0,4.3);
    \draw (6,4.1)--(6,4.3);
@@ -240,12 +240,12 @@ work.
    \draw (6.1,4)--(6.3,4);
 \draw (3,4.2) node[inner sep=2pt,fill=white] {$x$};
 \draw (6.2,2) node[inner sep=2pt,fill=white] {$y$};
-​       ​       ​       ​
-​       ​       ​       ​
-​       ​       ​       \end{tikzpicture}
-​       ​       \end{center}
-​       ​       %\caption{Useful figure for Problem 4}
-​       \end{figure}
+                     
+                     
+                     \end{tikzpicture}
+              \end{center}
+              %\caption{Useful figure for Problem 4}
+       \end{figure}
 
 \newpage
 

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm2-PracticeB.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm2-PracticeB.tex
@@ -223,33 +223,33 @@ $f''(x)>0$ on $(-\infty, 1)$
 $f''(x)<0$ on $( 1,\infty)$
 
 
-​        \begin{tikzpicture}[scale=1]
-​        \draw[gray!60] (-7, -7) grid[step=1] (7, 7);
-​        \draw[<->, thick,black] (-8,0)--(8,0) node[right]{$x$};
-​        \draw[<->, thick,black] (0,-8)--(0,8) node[above]{$y$};
-​        \foreach \x in {-7,-6,...,7}
-​        \draw[thick] (\x,-.1) --(\x,.1)node[below]{\x};
-​        \foreach \y in {-7,-6,...,7}
-​        \draw[thick] (-.1,\y) --(.1,\y)node[left]{\y};
-​        \end{tikzpicture}
-​
-​
+        \begin{tikzpicture}[scale=1]
+        \draw[gray!60] (-7, -7) grid[step=1] (7, 7);
+        \draw[<->, thick,black] (-8,0)--(8,0) node[right]{$x$};
+        \draw[<->, thick,black] (0,-8)--(0,8) node[above]{$y$};
+        \foreach \x in {-7,-6,...,7}
+        \draw[thick] (\x,-.1) --(\x,.1)node[below]{\x};
+        \foreach \y in {-7,-6,...,7}
+        \draw[thick] (-.1,\y) --(.1,\y)node[left]{\y};
+        \end{tikzpicture}
+
+
 
 \newpage
 
 \question[12]
-​        A rectangular sheep pen is to be enclosed by a wooden fence and divided into two
+        A rectangular sheep pen is to be enclosed by a wooden fence and divided into two
 equal parts by a chain link fence parallel to one of the sides. The wooden fencing will cost $\$4$
 per foot, while the chain link will cost $\$ 2 $ per foot. With $\$400$ to spend, what dimensions
 for the outer rectangle will create the largest total area? Justify your solution is optimal.
 
 \bigskip
 
-​        \begin{figure}[h]
-​        ​       \begin{center}
-​        ​       ​       \begin{tikzpicture}
-​        ​       ​       ​       \draw[thick] (0,0) -- (6,0)--(6,4)--(0,4)--(0,0);
-​        ​       ​       ​       \draw[thick, dashdotdotted] (3,0) --(3,4);
+        \begin{figure}[h]
+               \begin{center}
+                      \begin{tikzpicture}
+                             \draw[thick] (0,0) -- (6,0)--(6,4)--(0,4)--(0,0);
+                             \draw[thick, dashdotdotted] (3,0) --(3,4);
     \draw (0,4.2)--(6,4.2);
 
    \draw (0,4.1)--(0,4.3);
@@ -259,12 +259,12 @@ for the outer rectangle will create the largest total area? Justify your solutio
    \draw (6.1,4)--(6.3,4);
 \draw (3,4.2) node[inner sep=2pt,fill=white] {$x$};
 \draw (6.2,2) node[inner sep=2pt,fill=white] {$y$};
-​       ​       ​       ​
-​       ​       ​       ​
-​       ​       ​       \end{tikzpicture}
-​       ​       \end{center}
-​       ​       %\caption{Useful figure for Problem 4}
-​       \end{figure}
+                     
+                     
+                     \end{tikzpicture}
+              \end{center}
+              %\caption{Useful figure for Problem 4}
+       \end{figure}
 
 \newpage
 

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm2.tex
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm2.tex
@@ -225,16 +225,16 @@ $\displaystyle \lim_{x\to \infty}f(x)=-1$.
 
 
 \begin{center}
-​      \begin{tikzpicture}[scale=1.2]
-​      \draw[gray!60] (-6, -6) grid[step=1] (6, 6);
-​      \draw[<->, thick,black] (-6.5,0)--(6.5,0) node[right]{$x$};
-​      \draw[<->, thick,black] (0,-6.5)--(0,6.5) node[above]{$y$};
-​      \foreach \x in {-6,-5,...,6}
-​      \draw[thick] (\x,-.1) --(\x,.1)node[below]{\x};
-​      \foreach \y in {-6,-5,...,6}
-​      \draw[thick] (-.1,\y) --(.1,\y)node[left]{\y};
-​      \end{tikzpicture}
-\end{center}​
+      \begin{tikzpicture}[scale=1.2]
+      \draw[gray!60] (-6, -6) grid[step=1] (6, 6);
+      \draw[<->, thick,black] (-6.5,0)--(6.5,0) node[right]{$x$};
+      \draw[<->, thick,black] (0,-6.5)--(0,6.5) node[above]{$y$};
+      \foreach \x in {-6,-5,...,6}
+      \draw[thick] (\x,-.1) --(\x,.1)node[below]{\x};
+      \foreach \y in {-6,-5,...,6}
+      \draw[thick] (-.1,\y) --(.1,\y)node[left]{\y};
+      \end{tikzpicture}
+\end{center}
 
 
 
@@ -295,10 +295,10 @@ with 300 meters of fencing available to use, what dimensions for the outer recta
 the largest total area? Show all work, including justification that your solution is optimal.
 
 \begin{figure}[h]
-​       ​       \begin{center}
-​       ​       ​        \begin{tikzpicture}
-​       ​       ​        ​       \draw[thick,dashed] (0,0) -- (6,0)--(6,4)--(0,4)--(0,0);
-​       ​       ​        ​       \draw[thick,dashed] (3,0) --(3,4);
+              \begin{center}
+                      \begin{tikzpicture}
+                             \draw[thick,dashed] (0,0) -- (6,0)--(6,4)--(0,4)--(0,0);
+                             \draw[thick,dashed] (3,0) --(3,4);
    \draw[ultra thick] (-2,0)--(8,0);
   % \foreach \x in {-2,-1,...,8}
    %\draw[thick] (\x,0) --(\x-0.25,-0.25);
@@ -311,12 +311,12 @@ the largest total area? Show all work, including justification that your solutio
    \draw (6.1,4)--(6.3,4);
 \draw (3,4.2) node[inner sep=2pt,fill=white] {$x$};
 \draw (6.21,2) node[inner sep=2pt,fill=white] {$y$};
-​       ​       ​        ​
-​       ​       ​        ​
-​       ​       ​        \end{tikzpicture}
-​       ​       \end{center}
-​       ​       %\caption{Useful figure for Problem 4}
-​       \end{figure}
+                      
+                      
+                      \end{tikzpicture}
+              \end{center}
+              %\caption{Useful figure for Problem 4}
+       \end{figure}
 
 \newpage
 


### PR DESCRIPTION
## Summary
- remove stray zero-width space characters from the Math211 Fall 2024 exam TeX sources
- ensure figures, parts lists, and question prompts no longer contain invisible formatting artifacts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e79587bb6083288d34ae8317793b49