### PR TITLE
Handle exam questions without renaming worksheets

### DIFF
--- a/source/ch-2024-fall-exams/Math211Fa24-FinalExam-PracticeA.ptx
+++ b/source/ch-2024-fall-exams/Math211Fa24-FinalExam-PracticeA.ptx
@@ -1,0 +1,349 @@
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Math211Fa24-FinalExam-PracticeA" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Math211Fa24-FinalExam-PracticeA</title>
+	<exercise>
+		<introduction>
+			<p>
+				Are each of the following true or false statements? Fill in the bubble next to the correct answer. Justification is not necessary.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					If <m>f(x,y)=\dfrac{\ln(2x)}{y}</m>, the domain of <m>f(x,y)</m> is <m>\{(x,y)|x&gt;0, y&gt;0\}.</m>
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The improper integral <m>\displaystyle\int_{9}^\infty \dfrac{4}{x^2}dx</m> is divergent.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The improper integral <m>\displaystyle\int_{9}^\infty \dfrac{4}{\sqrt{x}}dx</m> is divergent.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					An equation for the tangent line of <m>f(x)=2x^3+4x</m> at <m>x=-1</m> is <m>y=10x+4</m>.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The area between the curves <m>y=\frac{x^2}{4}-2</m> and <m>y=\frac{x}{2}</m> (see graph below) is given by the integral <m>\displaystyle\int_{-2}^4\left(\frac{x^2}{4}-2-\frac{x}{2}\right)dx</m>.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Calculate the derivative of each function. You do not need to simplify your answer.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<m>f(x)=\displaystyle\frac{1}{2x^4}-\sqrt{3x}+e^2</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>\displaystyle g(x)=e^{x^2+2x}</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>F(x)=(3x^4+e^x)^8</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>r(x)=(4x^3+7x)\ln(x)</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Calculate each integral. You do not need to simplify your answer. Show all work.
+			</p>
+			<p>
+				​
+			</p>
+		</introduction>
+		<task workspace="1.75in">
+			<statement>
+				<p>
+					<m>\displaystyle\int \left(10x^4+\dfrac{8}{x}+\dfrac{3}{x^2}\right)dx</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>\displaystyle\int \sqrt{x}(4x^3+7) dx</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>\displaystyle\int \left( 4e^{2x} + \dfrac{1}{2} \right)dx</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				A company’s marginal cost function is <m>MC(x)=2e^{-x}</m>, where <m>x</m> is the number of units. Find the total cost of producing the first hundred units (<m>x=0</m> to <m>x=100</m>). Show all work. You do not need to simplify your final numerical answer. ​
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the average value of <m>f(x)=x-3\sqrt{x}</m> on the interval <m>[1,4]</m>.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				A parking lot owner has <m>450</m> parking spots to rent out. If the owner charges <m>x</m> dollars per parking spot, the number of spots that will be rented out is given by the function
+			</p>
+			<p>
+				<me>f(x)= 450-10x.</me>
+			</p>
+		</introduction>
+		<task workspace="3in">
+			<statement>
+				<p>
+					Find <m>R(x)</m>, where <m>R(x)</m> is the revenue the parking lot owner receives as a function of <m>x</m>.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					What price should the parking lot owner charge to maximize revenue? Justify your solution is optimal. Show all work.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Reminder: If <m>d(x)</m> is the demand function, and <m>s(x)</m> is the supply function,
+			</p>
+			<p>
+				<m>(\text{Consumers' surplus for $d(x)$ at demand level $A$})=\displaystyle\int_0^A[d(x)-B]dx</m> (where <m>B=d(A)</m>)
+			</p>
+			<p>
+				<m>(\text{Producers' surplus for $s(x)$ at demand level $A$})=\displaystyle\int_0^A[B-s(x)]dx</m> (where <m>B=s(A)</m>)
+			</p>
+			<p>
+				Suppose a product has demand function <m>d(x)=300-\frac{1}{2}x^2</m> and supply function <m>s(x)=\frac{1}{4}x^2</m>.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find the <term>producers’ surplus</term> at demand level <m>A=10</m>. Show all work. Evaluate the integral, but you do not need to simplify your final numerical answer.
+				</p>
+			</statement>
+		</task>
+		<task workspace="3in">
+			<statement>
+				<p>
+					Find the <term>market demand</term> (the positive value of <m>x</m> where supply and demand are equal). Show all work. Simplify your final answer.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For <m>f(x,y)=x^3+y^2-12x+6y</m>:
+			</p>
+		</introduction>
+		<task workspace="2in">
+			<statement>
+				<p>
+					Find the partial derivative <m>f_x</m>.
+				</p>
+			</statement>
+		</task>
+		<task workspace="2in">
+			<statement>
+				<p>
+					Find the partial derivative <m>f_y</m>.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find all the critical points of <m>f(x,y)</m>. Write each in the form <m>(x,y)</m>. Show all work.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Use the graph of <m>y=f'(x)</m> to answer the following. Briefly justify your answers.
+			</p>
+			<p>
+				Again, <term>this is the graph of the derivative of <m>f(x)</m>.</term>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					On which interval(s) is <m>f(x)</m> increasing? Briefly justify your answer.
+				</p>
+				<p>
+					​
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Is <m>f(x)</m> concave up or concave down at <m>x=-4</m>? Briefly justify your answer.
+				</p>
+				<p>
+					​
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					What is <m>\displaystyle \lim_{h\to0}\frac{f(3+h)-f(3)}{h}</m>? Briefly justify your answer.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For the function <m>f(x,y)=x^3-y^3-9xy+4</m>:
+			</p>
+		</introduction>
+		<task workspace="3in">
+			<statement>
+				<p>
+					Compute <m>f_{xx}, f_{yy},</m> and <m>f_{xy}</m>. Show all work.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The critical points of <m>f(x,y)</m> are <m>(0,0)</m> and <m>(-3,3)</m>. Determine, using the <m>D</m>-test, if each point corresponds to a relative maximum, relative minimum, or saddle point. Show all work.
+				</p>
+				<p>
+					Reminder: <m>D=f_{xx}(a,b)f_{yy}(a,b)-[f_{xy}(a,b)]^2</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+</worksheet>

--- a/source/ch-2024-fall-exams/Math211Fa24-FinalExam-PracticeB.ptx
+++ b/source/ch-2024-fall-exams/Math211Fa24-FinalExam-PracticeB.ptx
@@ -1,0 +1,376 @@
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Math211Fa24-FinalExam-PracticeB" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Math211Fa24-FinalExam-PracticeB</title>
+	<exercise>
+		<introduction>
+			<p>
+				Clearly mark the correct answer(s) for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> The reproduction function for salmon in a fishery is
+				</p>
+				<p>
+					<m>f(p)=-\frac{1}{10}p^2+13p</m>, where <m>p</m> and <m>f(p)</m> are in the thousands. The maximum sustainable yield is which of the following?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>60</m> thousand
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>360</m> thousand
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>420</m> thousand
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> If <m>f(x,y)</m> has a critical point where <m>f_{xx}</m> and <m>f_{yy}</m> are both positive, then...
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>f</m> must have a relative minimum at that point.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>f</m> must have a relative maximum at that point.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>f</m> must have saddle point at that point.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								There is not enough information to classify the critical point.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(True/False)</term> If <m>C(x,y)</m> is the cost function for a soda factory for <m>x</m> units of Coca-Cola and <m>y</m> units of Sprite, <m>C_x(x,y)</m> is the marginal cost function for Sprite when the production of Coca-Cola is held constant.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(True/False)</term> <m>\displaystyle\int_0^\infty \frac{1}{10000}dx</m> converges.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Suppose a study indicates that the distribution of income for lawyers is given by the Lorenz curve <m>L(x)=x^2</m>. Suppose the Gini index for doctors is <m>0.5</m>. Which profession has the more equal distribution of income?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								Lawyers
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								Doctors
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								They are the same.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				The demand function <m>d(x)</m> and supply function <m>s(x)</m> for a particular commodity are given as: <me>d(x)=131-\frac{1}{3}x^2, \; \; s(x)=50+\frac{2}{3}x^2</me>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find the consumers’ surplus at demand level <m>A=3</m>. You do not need to simplify your final numerical answer.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the market demand (the positive value of <m>x</m> at which the demand function intersects the supply function).
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the producers’ surplus at market demand. You do not need to simplify your final numerical answer.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Evaluate the following improper integral or show that it is divergent.
+			</p>
+			<p>
+				<m>\displaystyle\int_0^\infty \dfrac{e^{2x}-e^{4x}}{e^{6x}}dx</m>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Calculate the derivative of each function. You do not need to simplify your answer.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<m>f(x)=\dfrac{1}{x}+4\sqrt{x}-\sqrt{5}</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>\displaystyle g(x)=\ln(3x-x^2)</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>F(x)=e^x(x^3+3x)</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>r(x)=\sqrt[3]{x^3+1}</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Calculate each integral. You do not need to simplify your answer. Show all work.
+			</p>
+			<p>
+				​
+			</p>
+		</introduction>
+		<task workspace="1.75in">
+			<statement>
+				<p>
+					<m>\displaystyle\int x^2(1-4x^3)dx</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>\displaystyle\int \frac{1-\sqrt{x}}{\sqrt{x}} dx</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>\displaystyle\int \left(\dfrac{3}{2x}+e^{-x}\right)dx</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				The promoters of a state fair estimate that <m>t</m> hours after the gates open at 9:00am, visitors will be entering the fair at the rate of <m>N'(t)=16-t^2</m> hundred people per hour. Find the total number of people who will enter the fair between 11:00am and 2:00pm. You do not need to simplify the final numerical answer, but provide units. ​
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Set up and evaluate the integral to compute the shaded area (see below) bounded by the graphs <m>y=3-2x-x^2</m> and <m>y=x-1</m>. You do not need to simplify your final numerical answer.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For the function <m>f(x,y)=x^2+2y^2-x^2y</m>:
+			</p>
+		</introduction>
+		<task workspace="3in">
+			<statement>
+				<p>
+					Compute <m>f_{xx}, f_{yy},</m> and <m>f_{xy}</m>. Show all work.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The critical points of <m>f(x,y)</m> are <m>(0,0), (2,1)</m>, and <m>(-2,1)</m>. Determine, using the <m>D</m>-test, if each point corresponds to a relative maximum, relative minimum, or saddle point. Show all work.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Given the following information about two functions, <m>g(x)</m> and <m>f(x)</m>:
+			</p>
+			<p>
+				Compute each of the following. Simplify your answers.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<m>f(3)=4</m> <m>f'(3)=-7</m> ​
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>g(3)=2</m> <m>g'(3)=5</m> ​
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>f(6)=8</m> <m>f'(6)=3</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>g(6)=9</m><m>g'(6)=10</m> ​
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>h'(3)</m> if <m>h(x)=f(x)g(x)</m>. ​
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>h'(6)</m> if <m>h(x)=\dfrac{3f(x)}{4}</m>. ​
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>\displaystyle \lim_{h\to 0}\dfrac{f(h+3)-f(3)}{h}</m>.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The average value of <m>g'(x)</m> on <m>[3,6]</m>. ​
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The relative rate of change of <m>g(x)</m> at <m>x=3</m>.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+</worksheet>

--- a/source/ch-2024-fall-exams/Math211Fa24-FinalExam.ptx
+++ b/source/ch-2024-fall-exams/Math211Fa24-FinalExam.ptx
@@ -1,0 +1,461 @@
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Math211Fa24-FinalExam" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Math211Fa24-FinalExam</title>
+	<exercise>
+		<introduction>
+			<p>
+				Find each derivative. You do not need to simplify your answers.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find <m>r'(t)</m> if <m>r(t)=\ln(t^4-2t)</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find <m>f'(x)</m> if <m>f(x)=\sqrt{4x^2-7x}</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find <m>y'</m> if <m>y=\dfrac{3}{4x^2}+\dfrac{1}{\sqrt[3]{x}}+e^6</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find <m>g'(x)</m> if <m>g(x)=8e^xx^3</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find <m>f''(x)</m> if <m>f(x)=(x^2+1)^7</m>. You do not need to simplify your final answer.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Clearly mark the correct answer(s) for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Let <m>N(t)</m> represent a country’s national debt at time <m>t</m> years after 2010. Suppose the country finds that in 2022 (<m>t=12</m>), the national debt is rising, but more and more slowly. Which of the following is true?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>N'(12)</m> and <m>N''(12)</m> are both positive.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>N'(12)</m> and <m>N''(12)</m> are both negative.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>N'(12)</m> is positive, while <m>N''(12)</m> is negative.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>N'(12)</m> is negative, while <m>N''(12)</m> is positive.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task workspace="0.15in">
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Let <m>f(x,y)=\ln(y)+\dfrac{1}{x^2+1}</m>. Which of the following is the domain of <m>f(x,y)</m>?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>\{(x,y)|\, x\neq 0, y\geq0\}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\{(x,y)|\,y&gt;0\}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\{(x,y)|\,x\neq -1, y\geq 0\}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\{(x,y)|\,x\neq -1, y&gt;0\}</m>
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(True/False)</term> An equation for the tangent line of <m>f(x)=2x^2+3x</m> at <m>x=-2</m> is <m>y=-5x-8</m>.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> On a summer afternoon, a city’s electricity consumption is given by the rate <m>E(t)</m> in units per hour, where <m>t</m> is the number of hours after noon (<m>0\leq t \leq 6</m>). Which of the following represents the total consumption of electricity between the hours of 1 p.m. and 4 p.m.?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>\displaystyle \int_0^4 E(t)\; dt</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\displaystyle \int_1^4 E(t)\; dt</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>E(4)-E(0)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>E(4)-E(1)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Suppose a study indicates that the distribution of income for basketball players given by the Lorenz curve <m>L(x)=x^3</m>. Suppose the Gini index for football players is <m>0.3</m>. Which profession has the more equal distribution of income?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								Basketball players
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								Football players
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								They are the same.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task workspace="0.15in">
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> If <m>g'(x) = 4e^{2x}</m> and <m>g(0)=5</m>, what is <m>g(x)</m>?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>g(x)=2e^{2x}+3</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>g(x)=4e^{2x}+3</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>g(x)=2e^{2x}+5</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>g(x)=4e^{2x}+5</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Which of the following integrals correctly computes the shaded area between <m>y=x^2+1</m> and <m>y=4-2x</m> (shown below)?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>\displaystyle \int_{2}^{10} (x^2-3-2x)dx</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\displaystyle \int_{-3}^1 (x^2-3-2x)dx</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\displaystyle \int_{-3}^1 (5-2x-x^2)dx</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\displaystyle \int_{-3}^1 (3-2x-x^2)dx</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the average value of <m>f(x)=6x+\dfrac{3}{4x}</m> on <m>[2,5]</m>. Show all work. You do not need to simplify your final numerical answer.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				A concert venue seats 200 people. When they price the tickets at <m>\$60</m>, all 200 tickets will sell. They estimate that for each <m>\$3</m> increase in price, they will sell 5 fewer tickets. Find the price of concert ticket which will maximize their revenue. Justify your solution gives the maximum revenue. Show all work.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				The demand function <m>d(x)</m> and supply function <m>s(x)</m> for a particular commodity are given as: <me>d(x)=330-2x, \; \; s(x)=3x^2+x</me>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find the <term>consumers’ surplus</term> at demand level <m>A=5</m>. You do not need to simplify your final numerical answer. Show all work.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the <term>producers’ surplus</term> at demand level <m>A=5</m>. You do not need to simplify your final numerical answer. Show all work.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the market demand (the positive value of <m>x</m> at which the demand function equals the supply function). Show all work.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For <m>f(x,y)=6x^2-2x^3+3y^2+6xy</m>:
+			</p>
+		</introduction>
+		<task workspace="3in">
+			<statement>
+				<p>
+					Find <m>f_x, f_y, f_{xx}, f_{yy}</m>, and <m>f_{xy}</m>.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The critical points of <m>f(x,y)</m> are <m>(0,0)</m> and <m>(1,-1)</m>. Determine, using the <m>D</m>-test, if each point corresponds to a relative maximum, relative minimum, or saddle point. Show all work.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Evaluate the following improper integral or show that it is divergent. Show all work.
+			</p>
+			<p>
+				<m>\displaystyle\int_0^\infty \dfrac{2e^{x}+4e^{2x}}{e^{3x}}dx</m>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For <m>f(x,y)=x^3-4xy-8y+3</m>:
+			</p>
+		</introduction>
+		<task workspace="1.5in">
+			<statement>
+				<p>
+					Compute <m>f(-1,2)</m>. Simplify your answer to a single number.
+				</p>
+			</statement>
+		</task>
+		<task workspace="1.5in">
+			<statement>
+				<p>
+					Find the partial derivative <m>f_x</m>.
+				</p>
+			</statement>
+		</task>
+		<task workspace="1.5in">
+			<statement>
+				<p>
+					Find the partial derivative <m>f_y</m>.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the critical point(s) of <m>f(x,y)</m>. Write each in the form <m>(x,y)</m>. Show all work.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Use the graph of <m>y=f'(x)</m> to answer the following. No justification is required.
+			</p>
+			<p>
+				Again, <term>this is the graph of the derivative of <m>f(x)</m>.</term>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					On which interval(s) is <m>f(x)</m> decreasing?
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					At which <m>x</m>-value(s) does <m>f(x)</m> have a horizontal tangent line?
+				</p>
+				<p>
+					​
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					What is <m>\displaystyle \lim_{h\to0}\frac{f(h)-f(0)}{h}</m>? ​
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Is <m>f(x)</m> concave up or concave down at <m>x=2</m>?
+				</p>
+			</statement>
+		</task>
+	</exercise>
+</worksheet>

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm1-PracticeA.ptx
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm1-PracticeA.ptx
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Math211Fa24-Midterm1-PracticeA" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Math211Fa24-Midterm1-PracticeA</title>
+	<exercise>
+		<introduction>
+			<p>
+				Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice)</term> The cost of producing <m>x</m> ounces of gold from a new gold mine is <m>C(x)</m> dollars. What does the statement <m>C'(500) = 17</m> mean?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								The total cost to produce 17 ounces of gold is approximately $500.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								After 500 ounces of gold have been produced, the average production cost is $17/ounce. So the cost of producing 500 ounces is about $17/ounce.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								After 500 ounces of gold have been produced, the rate at which the production cost is increasing is $17/ounce. So the cost of producing the 500th (or 501st) ounce is about $17.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								After 17 ounces of gold have been produced, the average production cost is $500/ounce. So the cost of producing 17 ounces is about $500/ounce.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(True/False)</term> If <m>f(t)</m> is the function describing (in feet) the water level in a lake at time <m>t</m> (where <m>t</m> is in hours), and <m>f'(3)=10</m> and <m>f''(3)=-2</m>, then the water level is rising at <m>t=3</m>, but the rate is slowing.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(True/False)</term> The graph below describes a function in <m>x</m>.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Calculate the derivative of each function. You do not need to simplify your answer.
+			</p>
+		</introduction>
+		<task workspace="2in">
+			<statement>
+				<p>
+					<m>g(x)=\dfrac{4}{x^3} + 7</m>
+				</p>
+			</statement>
+		</task>
+		<task workspace="2in">
+			<statement>
+				<p>
+					<m>F(x)=(x+1)(2x+3)</m>
+				</p>
+			</statement>
+		</task>
+		<task workspace="2in">
+			<statement>
+				<p>
+					<m>r(x)=\displaystyle\sqrt{2x-3}</m>
+				</p>
+			</statement>
+		</task>
+		<task workspace="2in">
+			<statement>
+				<p>
+					<m>f(x)=(x^2+2x)^8</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find each limit. Show all work. Simplify your final answers.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<m>\displaystyle\lim_{x\to 3} \dfrac{ x^2-x-6}{x^2+2x-15}</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>\displaystyle \lim_{x\to 0}\dfrac{3x-5}{x^2+3}</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find an equation for the tangent line of <m>f(x)=x^3-5x^2+2</m> at <m>x=1</m>. Show all work.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find <m>f''(x)</m> of <m>f(x)=4x(x+1)</m>. You do not need to simplify your final answer. Show all work.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				A baseball bat manufacturer finds that the cost of making <m>x</m> bats is <m>C(x)=40+10x</m>, and the revenue in selling <m>x</m> bats is <m>R(x)=28x-2x^2</m>.
+			</p>
+		</introduction>
+		<task workspace="2in">
+			<statement>
+				<p>
+					Find all <m>x</m> value(s) where <m>R(x)=C(x)</m>. Show your work.
+				</p>
+			</statement>
+		</task>
+		<task workspace="2in">
+			<statement>
+				<p>
+					Find the <term>marginal revenue function</term> <m>MR(x)</m> and evaluate <m>MR(2)</m>. You do not need to simplify your final numerical answer.
+				</p>
+			</statement>
+		</task>
+		<task workspace="1in">
+			<statement>
+				<p>
+					Find the <term>average cost function</term> <m>AC(x)</m>.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the <term>marginal average cost function</term> <m>MAC(x)</m> and evaluate <m>MAC(2)</m>. You do not need to simplify your final numerical answer.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Consider the function <m>y=f(x)</m> below. Answer the following questions. ​ ​
+			</p>
+		</introduction>
+		<task workspace="1in">
+			<statement>
+				<p>
+					For which <m>x</m>-value(s) is <m>f'(x)=0</m>? Briefly (one sentence) explain your answer.
+				</p>
+			</statement>
+		</task>
+		<task workspace="1in">
+			<statement>
+				<p>
+					Is <m>f'(-1)</m> positive, negative, or zero? Briefly (one sentence) explain your answer.
+				</p>
+			</statement>
+		</task>
+		<task workspace="1in">
+			<statement>
+				<p>
+					Is <m>f'(2)</m> positive, negative, or zero? Briefly (one sentence) explain your answer.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Use the (limit) definition of the derivative, <me>\displaystyle f'(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h},</me> to compute <m>f'(x)</m> for <m>f(x)=3x^2-4</m>.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For the graph of <m>y=f(x)</m> below:
+			</p>
+		</introduction>
+		<task workspace="1in">
+			<statement>
+				<p>
+					Give all <m>x</m>-values where <m>f(x)</m> is discontinuous.
+				</p>
+			</statement>
+		</task>
+		<task workspace="0.5in">
+			<statement>
+				<p>
+					Find each value, if possible. If not possible, write DNE.
+				</p>
+				<p>
+					(a) <m>\displaystyle \lim_{x\to 1^-} f(x)=</m>
+				</p>
+				<p>
+					(b) <m>\displaystyle \lim_{x\to 1^+} f(x)=</m>
+				</p>
+				<p>
+					(c) <m>\displaystyle \lim_{x\to 1} f(x)=</m>
+				</p>
+				<p>
+					(d) <m>\displaystyle \lim_{x\to 3} f(x)=</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<task workspace="1in">
+			<statement>
+				<p>
+					Given the graph of <m>y=f(x)</m> below, give the domain and the range of <m>f(x)</m>. Use interval notation.
+				</p>
+				<p>
+					Domain:
+				</p>
+				<p>
+					Range:
+				</p>
+			</statement>
+		</task>
+		<task workspace="1.5in">
+			<statement>
+				<p>
+					Simplify <m>\dfrac{x^2}{4\sqrt{x}}</m> to the form <m>ax^b</m>, where <m>a</m> and <m>b</m> are both numbers.
+				</p>
+			</statement>
+		</task>
+		<task workspace="0.5in">
+			<statement>
+				<p>
+					For <m>f(x)=2x-1</m> and <m>g(x)=\sqrt{x+3}</m>, Write down expressions for each function composition. You do not need to simplify.
+				</p>
+				<p>
+					<m>f(g(x))=</m>
+				</p>
+				<p>
+					<m>g(f(x))=</m>
+				</p>
+				<p>
+					<m>f(f(x))=</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+</worksheet>

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm1-PracticeB.ptx
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm1-PracticeB.ptx
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Math211Fa24-Midterm1-PracticeB" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Math211Fa24-Midterm1-PracticeB</title>
+	<exercise>
+		<introduction>
+			<p>
+				Clearly mark the correct answer(s) for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Where does <m>f(x)=x-3\sqrt{x}</m> have a horizontal tangent line?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>x=0</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=1</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=\frac{1}{2}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=\frac{9}{4}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(True/False)</term> If <m>f(x)=x^2+2</m> and <m>g(x)=4x+3</m>, <m>f(g(x))=g(f(x))</m>.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Choose all that apply)</term> Given the graph of <m>y=f(x)</m> below, where is <m>f(x)</m> discontinuous?
+				</p>
+			</statement>
+				<choices multiple-correct="yes">
+					<choice>
+						<statement>
+							<p>
+								<m>x=-1</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=1</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=3</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Calculate the derivative of each function. You do not need to simplify your answer.
+			</p>
+		</introduction>
+		<task workspace="2in">
+			<statement>
+				<p>
+					<m>\displaystyle g(x)=x^3-3(x^2+10^2)</m>
+				</p>
+			</statement>
+		</task>
+		<task workspace="2in">
+			<statement>
+				<p>
+					<m>\displaystyle r(x)=\sqrt{x+\sqrt{x}}</m>
+				</p>
+			</statement>
+		</task>
+		<task workspace="2in">
+			<statement>
+				<p>
+					<m>\displaystyle f(t)=\frac{7}{t^{4/3}}-8t</m>
+				</p>
+			</statement>
+		</task>
+		<task workspace="2in">
+			<statement>
+				<p>
+					<m>f(x)=(x^3+2x-7)(x^4-3x^2+x)</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Given the graph of <m>f(x)</m> and the graph of <m>g(x)</m> below:
+			</p>
+			<p>
+				Find each limit. Show all work. Simplify your final answers.
+			</p>
+		</introduction>
+		<task workspace="1in">
+			<statement>
+				<p>
+					Give the domain and range of <m>f(x)</m>. Use interval notation.
+				</p>
+			</statement>
+		</task>
+		<task workspace="1in">
+			<statement>
+				<p>
+					Give the domain and range of <m>g(x)</m>. Use interval notation.
+				</p>
+			</statement>
+		</task>
+		<task workspace="1in">
+			<statement>
+				<p>
+					What is <m>g(f(-3))</m>?
+				</p>
+			</statement>
+		</task>
+		<task workspace="1in">
+			<statement>
+				<p>
+					Find <m>F'(2)</m>, where <m>F(x)=f(x)g(x)</m>. You do not need to simplify your final numerical answer.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>\displaystyle\lim_{x\to 1} \dfrac{x^2-4x+4}{x^3+5x^2-14x}</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>\displaystyle\lim_{x\to 4} \dfrac{x^2+x-20}{2x^2-6x-8}</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find an equation for the tangent line of the function <m>f(x)=x-2x^2</m> at <m>x=3</m>. Show all work.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find <m>g''(x)</m> of <m>g(x)=4\sqrt{x}-\dfrac{1}{x^2}</m>. You do not need to simplify your final answer. Show all work.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Suppose a USB manufacturer finds that the cost of producing <m>x</m> total USBs is <m>C(x)=40+24x^{1/3}</m>.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find the marginal cost function <m>MC(x)</m> and evaluate it at <m>x=8</m>. Simplify your answer.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the marginal average cost function <m>MAC(x)</m> and evaluate it at <m>x=8.</m> Simplify your answer.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Given the graph of <m>f(x)</m> below, find each limit. Write <m>\infty, -\infty</m>, or DNE if applicable.
+			</p>
+		</introduction>
+		<task workspace="0.5in">
+			<statement>
+				<p>
+					<m>\displaystyle\lim_{x\to 3^-}f(x)=</m> ​
+				</p>
+			</statement>
+		</task>
+		<task workspace="0.5in">
+			<statement>
+				<p>
+					<m>\displaystyle\lim_{x\to 3^+}f(x)=</m> ​ ​
+				</p>
+			</statement>
+		</task>
+		<task workspace="0.5in">
+			<statement>
+				<p>
+					<m>\displaystyle\lim_{x\to 3}f(x)=</m> ​
+				</p>
+			</statement>
+		</task>
+		<task workspace="0.5in">
+			<statement>
+				<p>
+					<m>\displaystyle\lim_{x\to 0}f(x)=</m> ​
+				</p>
+			</statement>
+		</task>
+		<task workspace="0.5in">
+			<statement>
+				<p>
+					<m>\displaystyle\lim_{x\to 2^-}f(x)=</m>
+				</p>
+			</statement>
+		</task>
+		<task workspace="0.5in">
+			<statement>
+				<p>
+					<m>\displaystyle\lim_{x\to 2^+}f(x)=</m>
+				</p>
+			</statement>
+		</task>
+		<task workspace="0.5in">
+			<statement>
+				<p>
+					<m>\displaystyle\lim_{x\to 2}f(x)=</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Use the limit definition of the derivative to compute <m>f'(x)</m> for <m>f(x)=3x+x^2</m>.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Suppose the graph below is <m>f'(x)</m>. Assume each tick mark is 1 unit.
+			</p>
+			<p>
+				​
+			</p>
+			<p>
+				​ ​
+			</p>
+		</introduction>
+		<task workspace="1.5in">
+			<statement>
+				<p>
+					At which <m>x</m>-values does <m>f(x)</m> have a horizontal tangent line? Briefly explain your answer.
+				</p>
+				<p>
+					​ ​
+				</p>
+			</statement>
+		</task>
+		<task workspace="1.5in">
+			<statement>
+				<p>
+					On which intervals is <m>f(x)</m> increasing? Briefly explain your answer.
+				</p>
+				<p>
+					​ ​
+				</p>
+			</statement>
+		</task>
+		<task workspace="1.5in">
+			<statement>
+				<p>
+					On which intervals is <m>f(x)</m> decreasing?Briefly explain your answer. ​
+				</p>
+			</statement>
+		</task>
+	</exercise>
+</worksheet>

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm1.ptx
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm1.ptx
@@ -1,0 +1,452 @@
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Math211Fa24-Midterm1" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Math211Fa24-Midterm1</title>
+	<exercise>
+		<introduction>
+			<p>
+				Clearly mark the correct answer(s) for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Let <m>f(x)</m> and <m>g(x)</m> be two functions such that <m>f(2) = -3</m>, <m>g(2) = 7</m>, <m>f'(2) = 3</m>, <m>g'(2) = 10</m>, and <m>f'(7) = 4</m>. Which of the following is the instantaneous rate of change of <m>f(g(x))</m> when <m>x = 2</m>?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								3
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								30
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								40
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								210
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task workspace="0.15in">
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Suppose <m>f(t)</m> represents the temperature <m>t</m> hours after noon. Suppose the temperature at 3:00pm (<m>t = 3</m>) is rising increasingly rapidly. Which of the following is true?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>f'(3)</m> is negative, while <m>f''(3)</m> is positive.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>f'(3)</m> is positive, while <m>f''(3)</m> is negative.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>f'(3)</m> and <m>f''(3)</m> are both positive.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>f'(3)</m> and <m>f''(3)</m> are both negative.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(True/False)</term> Suppose <m>g(x)</m> is a function with <m>\displaystyle\lim_{ x \to 4^+}
+											g(x) = 1</m>, <m>\displaystyle\lim_{x\to 4^-}g(x)=2</m>, and <m>g(4) = 2</m>. Then <m>g(x)</m> is continuous at <m>x=4</m>.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Which of the following is equal to <m>\dfrac{10}{\sqrt[3]{8x^2}}</m>?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>20x^{6}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>20x^{-3/2}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>5x^{-3/2}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> What is the domain of the function <m>y=f(x)</m> shown below?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>[1,6]</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>[-2,5]</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>(-2,2)\cup(2,5)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>[-2,2)\cup(2,5]</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Calculate the derivative of each function. You do not need to simplify your answers.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<m>f(x)=(x^3+2x-1)(x^2-10x)</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>g(x)=\dfrac{2}{7x^2}+3x^4+\sqrt{2}</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>r(t)=\sqrt[4]{t^2+t}</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>F(x)=(2x^6+x^2)^9+3x</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For the graph of <m>y=f(x)</m> below:
+			</p>
+		</introduction>
+		<task workspace="0.75in">
+			<statement>
+				<p>
+					For which <m>x</m>-value(s) is <m>f(x)</m> discontinuous?
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find each limit, if possible (use <m>+\infty</m> or <m>-\infty</m> if applicable). If not possible, write DNE.
+				</p>
+				<p>
+					(a) <m>\displaystyle \lim_{x\to -1} f(x)=</m>
+				</p>
+				<p>
+					(b) <m>\displaystyle \lim_{x\to 1^-} f(x)=</m>
+				</p>
+				<p>
+					(c) <m>\displaystyle \lim_{x\to 3^{-}} f(x)=</m>
+				</p>
+				<p>
+					(d) <m>\displaystyle \lim_{x\to 3^{+}} f(x)=</m>
+				</p>
+				<p>
+					(e) <m>\displaystyle \lim_{x\to 3} f(x)=</m>
+				</p>
+				<p>
+					(f) <m>\displaystyle \lim_{x\to 4} f(x)=</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find <m>f''(x)</m> for <m>f(x)=12\sqrt{x}(x+1)</m>. You do not need to simplify your final answer. Show all work.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Suppose a table manufacturer determines that their cost function <m>C(x)</m> (in dollars) for producing <m>x</m> tables is <m>C(x)=30x+50</m>, while their revenue function <m>R(x)</m> (in dollars) for selling <m>x</m> tables is <m>R(x)=45x-x^2</m>.
+			</p>
+		</introduction>
+		<task workspace="2in">
+			<statement>
+				<p>
+					Find the <term>profit function</term> <m>P(x)</m>, then find the <m>x</m>-value(s) where <m>P(x)=0</m>. Show all work.
+				</p>
+			</statement>
+		</task>
+		<task workspace="2in">
+			<statement>
+				<p>
+					Find the <term>marginal revenue function</term> and evaluate it at <m>x=10</m>. You do not need to simplify your numerical answer. Show all work.
+				</p>
+			</statement>
+		</task>
+		<task workspace="1in">
+			<statement>
+				<p>
+					Find the <term>average cost function</term>.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the <term>marginal average cost function</term> and evaluate it at <m>x=10</m>. You do not need to simplify your numerical answer. Show all work.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Use the limit definition of the derivative to compute <m>f'(x)</m>, where <m>f(x)=2x^2-6x</m>. Show all work.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find each limit. Show all work. Simplify your final answers.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<m>\displaystyle \lim_{x\to 3} \dfrac{x^2+x-12}{2x-6}</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>\displaystyle \lim_{x\to 0}\dfrac{x^2+5x+4}{x^2+3x-4}</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find an equation for the tangent line of <m>f(x)=x^4+2x+4</m> at <m>x=-1</m>. Show all work.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Consider the function <m>y=f(x)</m> below. Clearly mark the correct answer(s) for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term> ​ ​
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<term>(Choose all that apply)</term> For which <m>x</m>-value(s) is <m>f'(x)=0</m>?
+				</p>
+			</statement>
+				<choices multiple-correct="yes">
+					<choice>
+						<statement>
+							<p>
+								<m>x=-4</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=-2</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=2</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=4</m>
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Is <m>f'(-3)</m> positive, negative, or zero?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								positive
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								negative
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								zero
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Is <m>f'(1)</m> positive, negative, or zero?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								positive
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								negative
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								zero
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+</worksheet>

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm2-PracticeA.ptx
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm2-PracticeA.ptx
@@ -1,0 +1,353 @@
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Math211Fa24-Midterm2-PracticeA" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Math211Fa24-Midterm2-PracticeA</title>
+	<exercise>
+		<introduction>
+			<p>
+				Are each of the following true or false statements? Fill in the bubble next to the correct answer. Justification is not necessary.
+			</p>
+			<p>
+				Reminder: Elasticity <m>=E(p)=\dfrac{-pD'(p)}{D(p)}</m>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Suppose the demand function of a commodity is <m>D(p)=20-p</m>. If the current price is <m>p=5</m>, the demand is elastic.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The value of <m>\$1000</m> deposited in a bank at <m>12\%</m> interest compounded quarterly for 15 years is <m>1000(1.03)^{15}</m> dollars.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The function <m>f(x)=x^2-4x</m> has an absolute minimum value of <m>-3</m> on the interval <m>[3,6]</m>.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Use the given graph of the function <m>f</m> to answer the following questions. Fill in the bubble next to the correct answer. Justification is not necessary.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					The function is not differentiable at <m>x = -2.</m>
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The function is not differentiable at <m>x = -1.</m>
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The function is not differentiable at <m>x = 0.</m>
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The function is not differentiable at <m>x = 1.</m>
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The function is not differentiable at <m>x = 3.</m>
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The given function is
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								differentiable
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								nondifferentiable
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								neither
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Let <m>f(x)</m> be a continuous function with derivative <m>\displaystyle f'(x)=(x-2)^2(x+3)(x-5)</m>.
+			</p>
+		</introduction>
+		<task workspace="1.5in">
+			<statement>
+				<p>
+					Give all critical numbers for <m>f(x)</m>.
+				</p>
+			</statement>
+		</task>
+		<task workspace="4in">
+			<statement>
+				<p>
+					Using a sign chart, find the intervals of increasing and decreasing for <m>f(x)</m>. Write your answers using interval notation.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Classify each critical number as a relative minimum, relative maximum, or neither.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				On the axes below, draw the graph of a continuous function <m>f(x)</m> that satisfies the following:
+			</p>
+			<p>
+				​ <m>f(0)=5</m> ​ ​ <m>f'(0)=0</m> ​ ​ <m>f'(x)&gt;0</m> on <m>(-\infty, 0)</m> ​ ​ <m>f'(x)&lt;0</m> on <m>(0,\infty)</m> ​ ​ ​ <m>f''(x)&lt;0</m> on <m>(-\infty, 2)</m> ​ ​ <m>f''(x)&gt;0</m> on <m>(2,\infty)</m>
+			</p>
+			<p>
+				<m>\displaystyle\lim_{x\to\infty}f(x)=1</m>
+			</p>
+			<p>
+				​
+			</p>
+			<p>
+				​ ​
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				​ Farmer Stan is building a rectangular cattle pen to be enclosed by a fence and divided into three equal parts by two
+			</p>
+			<p>
+				​ additional fences parallel to one of the sides (see picture below). If he has 200 meters of fencing available to use, what dimensions for the outer rectangle (i.e., what values for <m>x</m> and <m>y</m>) will create the largest possible total area? Justify that your solution is optimal. Show all work.
+			</p>
+			<p>
+				​
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the intervals of concavity and inflection points (<m>x</m> values only) of <m>f(x)=\frac{1}{2}{x}^{4}-5{x}^{3}+12{x}^{2}+17x+89</m>. Give the intervals of concavity using interval notation. Show all work.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				An Etsy necklace maker finds that when they price their necklaces at <m>\$20</m>, they sell <m>100</m> necklaces in a month. They determine that for each <m>\$1</m> price increase, they will sell 4 fewer necklaces per month. If each necklace costs <m>\$5</m> to produce, what price should they charge to maximize profit? Justify your solution is optimal.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<task>
+			<statement>
+				<p>
+					After <m>t</m> days of advertisements for a new restaurant, the proportions of shoppers in a town who have seen the ads is <m>1-e^{-0.04t}.</m> How long must the ads run to reach 90% of the shoppers? You do not need to simplify your answer.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find <m>\dfrac{d}{dt}\ln(f(t))</m> (i.e. the relative rate of change) of <m>f(t)=t^2+1</m> at <m>t=2</m>.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					A car worth $15,000 depreciates in value by 15% each year. How much is it worth after 5 years? You do not need to simplify your answer.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Compute the following derivatives.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find <m>f'(x)</m> if <m>f(x) = \ln(x) \sqrt{x}.</m> You do not need to simplify your final answer.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find <m>g''(x)</m> if <m>g(x)=e^{x^3}</m>. You do not need to simplify your final answer.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+</worksheet>

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm2-PracticeB.ptx
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm2-PracticeB.ptx
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Math211Fa24-Midterm2-PracticeB" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Math211Fa24-Midterm2-PracticeB</title>
+	<exercise>
+		<introduction>
+			<p>
+				Clearly mark the correct answer(s) for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Suppose a rich aunt wants to buy you a car when you get your driver’s license. How much money must she deposit in a trust fund paying <m>4\%</m> interest compounded quarterly at the time of your birth to yield <m>\$30,000</m> on your 16th birthday?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>30000(1.01)^{64}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\dfrac{30000}{(1.01)^{64}}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\dfrac{30000}{(1.04)^{16}}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\dfrac{30000}{(1.01)^{16}}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> A store expects to sell 8000 bottles of perfume this year. The perfume costs the store owner <m>\$20</m> per bottle, there is an ordering fee of <m>\$100</m> per shipment, and the cost of storing the perfume is <m>\$10</m> per bottle per year. The perfume is consumed at a constant rate throughout the year, and each shipment arrives just as the preceding shipment is used up. Which of the following is the correct expression for the
+				</p>
+				<p>
+					yearly <term>storage costs</term> (in dollars) of the perfume with lot size <m>x</m>? (hint: average inventory is <m>x/2</m>).
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>5x</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>5x+100</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>25x+100</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>(20x+100)\dfrac{8000}{x}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Suppose monthly global data traffic is predicted to be <m>2.7e^{0.475x}</m> petabytes, where <m>x</m> is the number of years since 2016. Find the relative growth rate (per year) in 2026.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>2.7\%</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>47.5\%</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>2.7e^{47.5}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Choose all that apply)</term> Given the graph of <m>y=f(x)</m> below, where is <m>f(x)</m> nondifferentiable?
+				</p>
+			</statement>
+				<choices multiple-correct="yes">
+					<choice>
+						<statement>
+							<p>
+								<m>x=-1</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=0</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=1</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=2</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=3</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(True/False)</term> <m>f(x)=e^{x^2-x}</m> has a critical number at <m>x=0</m>.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(True/False)</term> A Hyundai Sonata lists for <m>\$ 22,000</m> and depreciates in value by <m>30\%</m> each year. In 3 years, it will be worth <m>22,000(.3)^3</m>.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For the demand function <m>D(p)=40-p</m>:
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find the elasticity of demand <m>E(p)</m> and evaluate it at <m>p=10.</m> Simplify your answer.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Is the demand elastic or inelastic at <m>p=10</m>? To increase revenue, should you increase or decrease the price?
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the price at which the demand is unit-elastic.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Suppose <m>f(x)</m> is a continuous function whose derivative is <m>f'(x)=x^{-1/3}(2-x)(x+4)^2</m>.
+			</p>
+		</introduction>
+		<task workspace="2in">
+			<statement>
+				<p>
+					What are the critical numbers of <m>f(x)</m>?
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					At what points, if any, does <m>f(x)</m> assume relative maximum and minimum values? Fully justify your answer.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				On the axes below, draw the graph of a function <m>f(x)</m> which is continuous everywhere except <m>x=1</m> that satisfies the following conditions:
+			</p>
+			<p>
+				<m>f(0)=1</m>
+			</p>
+			<p>
+				<m>f(x)</m> has a vertical asymptote at <m>x=1</m>
+			</p>
+			<p>
+				<m>f'(x)&lt;0</m> on <m>(4,\infty)</m>
+			</p>
+			<p>
+				<m>f'(x)&gt;0</m> on <m>(-\infty, 1)\cup(1,4)</m>
+			</p>
+			<p>
+				<m>f''(x)&gt;0</m> on <m>(-\infty, 1)</m>
+			</p>
+			<p>
+				<m>f''(x)&lt;0</m> on <m>( 1,\infty)</m>
+			</p>
+			<p>
+				​
+			</p>
+			<p>
+				​ ​
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				​ A rectangular sheep pen is to be enclosed by a wooden fence and divided into two equal parts by a chain link fence parallel to one of the sides. The wooden fencing will cost <m>\$4</m> per foot, while the chain link will cost <m>\$ 2</m> per foot. With <m>\$400</m> to spend, what dimensions for the outer rectangle will create the largest total area? Justify your solution is optimal.
+			</p>
+			<p>
+				​
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For <m>f(x)=x^4-4x^3+10</m>:
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find the intervals of increasing/decreasing. Give your answers using interval notation. Show all work.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the intervals of concave up/concave down. Give your answers using interval notation. Show all work.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				A bus company will rent a bus that holds 50 people to groups of 30 people or more. If a group contains exactly 30 people, each person pays <m>\$80</m>. In large groups, everybody’s fare is reduced by <m>\$2</m> for each person in excess of 30. Determine the size of the group for which the bus company’s revenue will be greatest. Justify why your solution is optimal.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the absolute maximum and absolute minimum of <m>g(x)=6x^2-x^3-6</m> on <m>[-1,3]</m>.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<task>
+			<statement>
+				<p>
+					Find <m>f'(x)</m> if <m>f(x) = \ln(x^2+2x)</m>. You do not need to simplify your final answer.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find <m>g'(x)</m> if <m>g(x)=e^{x^2+4x}</m>. You do not need to simplify your final answer.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+</worksheet>

--- a/source/ch-2024-fall-exams/Math211Fa24-Midterm2.ptx
+++ b/source/ch-2024-fall-exams/Math211Fa24-Midterm2.ptx
@@ -1,0 +1,409 @@
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Math211Fa24-Midterm2" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Math211Fa24-Midterm2</title>
+	<exercise>
+		<introduction>
+			<p>
+				Clearly mark the correct answer(s) for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> Which of the following is equal to
+				</p>
+				<p>
+					<m>\ln(3x^4)- 3\ln(x)</m>?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>\ln(x^{9})</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\ln(3)+\ln(x)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\ln(3)\ln(x)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task workspace="0.15in">
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> What are the vertical asymptotes of
+				</p>
+				<p>
+					<m>f(x)=\dfrac{x+3}{x^2+2x-8}</m>?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>x=-4</m> and <m>x=2</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=-4</m>, <m>x=-3</m>, and <m>x=2</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=-4</m>, <m>x=-3</m>, <m>x=1</m>, and <m>x=2</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(True/False)</term> If <m>g(x)</m> has an absolute maximum, then <m>g(x)</m> must have an absolute minimum.
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								True
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								False
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					If the elasticity of demand is <m>\dfrac{4}{3}</m> for a given price, is the demand elastic or inelastic, and should we raise or lower the price to increase revenue?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								Demand is <term>elastic</term>, and we should <term>raise</term> the price to increase revenue.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								Demand is <term>elastic</term>, and we should <term>lower</term> the price to increase revenue.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								Demand is <term>inelastic</term>, and we should <term>raise</term> the price to increase revenue.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								Demand is <term>inelastic</term>, and we should <term>lower</term> the price to increase revenue.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					A gift store expects to sell 500 candles this year. The candles costs the store owner <m>\$4</m> per candle, there is an ordering fee of <m>\$20</m> per shipment, and the cost of storing the candles is <m>\$2</m> per candle per year. The candle inventory is consumed at a constant rate throughout the year, and each shipment arrives just as the preceding shipment is used up. Which of the following is the correct expression for the yearly <term>total costs</term> (storage costs plus reorder costs) in dollars of the candles with lot size <m>x</m>? (Hint: The average inventory size is half the lot size.)
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>(4x+20) \left(\dfrac{500}{x}\right)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x+(4x+20)\left(\dfrac{500}{x}\right)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>4x+20</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>500+(4x+20) \left(\dfrac{500}{x}\right)</m>
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task workspace="0.15in">
+			<statement>
+				<p>
+					<term>(Multiple Choice-Choose one)</term> For <m>g(x)=\ln(e^x - 4x)</m>, which of the following is <m>g'(0)</m>?
+				</p>
+			</statement>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>g'(0)=-4</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>g'(0)=-3</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>g'(0)=0</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>g'(0)=1</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<term>(Select all that apply)</term> Given the graph of <m>y=f(x)</m> below, where is <m>f(x)</m> nondifferentiable?
+				</p>
+			</statement>
+				<choices multiple-correct="yes">
+					<choice>
+						<statement>
+							<p>
+								<m>x=-3</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=-1</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=0</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=1</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Suppose <m>f(x)</m> is a continuous function whose derivative is <m>f'(x)=-4(x-1)(x-2)^3(x+3)^2</m>.
+			</p>
+		</introduction>
+		<task workspace="1in">
+			<statement>
+				<p>
+					What are the critical numbers of <m>f(x)</m>?
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Using a sign chart, find the intervals of increasing and decreasing for <m>f(x)</m>. Write your answers using interval notation.
+				</p>
+			</statement>
+		</task>
+		<task workspace="1.5in">
+			<statement>
+				<p>
+					Classify each critical number as the location of a relative minimum, relative maximum, or neither. No justification is needed.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				On the axes below, draw the graph of a function <m>f(x)</m> which is <term>continuous</term> everywhere that satisfies all the following conditions:
+			</p>
+			<p>
+				<m>f(-2)=0</m> and <m>f(0)=3</m>.
+			</p>
+			<p>
+				<m>f(x)</m> is not differentiable at <m>x=-2</m>.
+			</p>
+			<p>
+				<m>f'(x)&gt;0</m> on <m>(-2,0)</m>.
+			</p>
+			<p>
+				<m>f'(x)&lt;0</m> on <m>(-\infty, -2)\cup(0,\infty)</m>.
+			</p>
+			<p>
+				<m>f''(x)&lt;0</m> on <m>( -\infty,-2)\cup(-2,2)</m>.
+			</p>
+			<p>
+				<m>f''(x)&gt;0</m> on <m>( 2,\infty)</m>.
+			</p>
+			<p>
+				<m>\displaystyle \lim_{x\to \infty}f(x)=-1</m>.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				A woodworker finds that when they price their cutting boards at <m>\$50</m>, they sell <m>30</m> cutting boards in a month. They determine that for each <m>\$1</m> price discount, they will sell 3 more cutting boards per month. If each cutting board costs <m>\$20</m> to produce, find the price of the cutting boards which will maximize their profit AND the number of cutting boards sold. Write each answer clearly with units, and justify your solution gives the maximum profit. Show all work.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<task>
+			<statement>
+				<p>
+					After <m>t</m> weeks of practice, a typing student can type <m>120(1-e^{-0.3t})</m> words per minute. How long will it take for the student to be able to type 100 words per minute? Show all work. You do not need to simplify your final answer, but include units.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					A rich aunt wants to give her nephew <m>\$45,000</m> when he turns 18. How much money must she deposit in a trust fund paying <m>8\%</m> compounded quarterly at the time of the nephew’s birth to yield <m>\$45,000</m> when he turns 18? Show all work. You do not need to simplify your answer.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the inflection point(s) (<m>x</m>-value(s) only) and intervals of concavity for
+			</p>
+			<p>
+				<m>f(x)=9x^2-x^3+10x+12</m>. Give the intervals of concavity using interval notation. Show all work.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				A dog daycare owner wants to build a rectangular fenced area along the side of the daycare building, split into two equal parts by a fence parallel to one of its sides (see picture below, the dashed lines denote fencing). If the side along the building needs no fence, with 300 meters of fencing available to use, what dimensions for the outer rectangle will create the largest total area? Show all work, including justification that your solution is optimal.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Compute the following:
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find <m>f'(x)</m> if <m>f(x) = x^2\ln(4x).</m> You do not need to simplify your final answer.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find <m>g''(x)</m> if <m>\displaystyle g(x)=e^{x^2+2x}</m>. You do not need to simplify your final answer.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<task>
+			<statement>
+				<p>
+					For the demand function <m>D(p)=60-p^2</m>, find the elasticity of demand <m>E(p)</m> and evaluate it at <m>p=5.</m> Show all work. You do not need to simplify your final numerical answer.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the relative rate of change of <m>f(t)=t^3+2t</m> at <m>t=3</m>. Show all work. You do not need to simplify your final numerical answer.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+</worksheet>


### PR DESCRIPTION
## Summary
- treat questions/parts environments like enumerations when building workspace metadata and when normalizing the LaTeX source
- normalize question/part commands before re-invoking pandoc while preserving the worksheet identifier metadata
- regenerate the Fall 2024 exam PreTeXt worksheets so their xml:id/title match the source names

## Testing
- `for f in source/ch-2024-fall-exams/*.tex; do out="${f%.tex}.ptx"; pandoc "$f" -t pretext.lua -o "$out"; done`

------
https://chatgpt.com/codex/tasks/task_e_68e7951350308328bf1fb60b61907f6f