### PR TITLE
Clean Math213 LaTeX exams and regenerate PreTeXt worksheets

### DIFF
--- a/pretext.lua
+++ b/pretext.lua
@@ -832,6 +832,10 @@ function Code(s, attr)
 end
 
 function InlineMath(s)
+  local currency_amount = s:match("^\\$([%d,%.%,%s]*%d)$")
+  if currency_amount then
+    return "$" .. escape(currency_amount)
+  end
   return "<m>" .. escape(s) .. "</m>"
 end
 

--- a/source/math213-exams/Math213-FinalExam.ptx
+++ b/source/math213-exams/Math213-FinalExam.ptx
@@ -147,7 +147,7 @@
 	<exercise>
 		<introduction>
 			<p>
-				Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
+				Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <em>No justification is needed.</em>
 			</p>
 		</introduction>
 		<task>

--- a/source/math213-exams/Math213-FinalExam.ptx
+++ b/source/math213-exams/Math213-FinalExam.ptx
@@ -1,7 +1,295 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<section xml:id="math213-final" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <title>Math 213 Final Exam Practice</title>
-  <raw format="latex" xml:space="preserve">
-    <xi:include href="./Math213-FinalExam.tex" parse="text"/>
-  </raw>
-</section>
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Math213-FinalExam" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Math213-FinalExam</title>
+	<exercise>
+		<introduction>
+			<p>
+				Consider the first-order linear differential equation <me>y' -\dfrac{3}{x}y = x^4.</me>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find the general solution of the differential equation.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the particular solution that satisfies the initial condition <m>y(1) = 5.</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For your retirement <q>nest egg,</q> you deposit $300 at the end of each month into a bank account paying 6% interest compounded monthly. Use your knowledge of series to find an expression that represents the amount of this annuity at the end of your 40-year working career. While you do not need to simplify your final answer, you do need to find a single term expression that represents the value of the annuity. Writing your answer as a sum of terms is not enough.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<task>
+			<statement>
+				<p>
+					Find the 3rd degree Taylor polynomial of <m>f(x) = \sqrt{x}</m> centered at <m>x=9.</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Use the 3rd degree Taylor polynomial that you found in part (a) to find an approximation for <m>\sqrt{10}</m> by evaluating the polynomial at an appropriate value of <m>x.</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Use known series expansions to find the Taylor Series of <m>f(x) = x^2 e^{2x}</m> centered at <m>x=0.</m> Give at least the first five terms of the series.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the volume under the surface <m>f(x,y) = 4y</m> and above the shaded region <m>R</m> shown in the graph.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Use the method of Lagrange multipliers to find the minimum of <m>f(x,y) = 4xy</m> subject to the constraint <m>2x+6y=12.</m>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Consider the initial-value problem <me>y' = 2x + y, \,\, y(0) = 2.</me> Use Euler’s method with <m>n = 2</m> steps to approximate <m>y(1).</m>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Consider the function <m>f(x) = x^2-x-2.</m> Use 2 iterations of Newton’s method starting with <m>x_0 = 1</m> to approximate a zero of <m>f(x).</m>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Consider a continuous random variable <m>X</m> with probability density function <m>f(x) =
+							\dfrac{3}{2}\sqrt{x}</m> on <m>[0,1].</m>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Compute the probability <m>P\left(X \ge \dfrac{1}{2} \right)</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the mean (i.e., the expected value) of <m>X.</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For the spinner below, the arrow is spun and then stops, pointing in one of the numbered sectors, with probability proportional to the area of the sector. Let <m>X</m> stand for the number so chosen. Find the following. (Leave your answers as fractions, integers, or exact decimals.)
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<m>P(X=8)=</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>E(X)=</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				A company’s profit <m>P(x,y)</m> from making <m>x</m> computers and <m>y</m> tablets per day is given by <m>P(x,y) = 4x^2-5xy +5y^2 +10x+4y+70.</m>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find the marginal profit function for computers.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the marginal profit function for tablets.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Consider the infinite series <m>\displaystyle\sum_{n=0}^{\infty}\dfrac{8}{6^n}.</m> What can you say about the convergence of this series?
+				</p>
+				<ul>
+					<li>
+						<p>
+							The series converges to <m>8/6.</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							The series converges to <m>\frac{8}{1-1/6}.</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							The series converges, but its value cannot be determined.
+						</p>
+					</li>
+					<li>
+						<p>
+							The series diverges.
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Consider the infinite series <m>\displaystyle\sum_{n=1}^{\infty}(-1)^{n-1}\dfrac{1}{n2^n}.</m> What can you say about the convergence of this series?
+				</p>
+				<ul>
+					<li>
+						<p>
+							The series converges to <m>\ln(3/2).</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							The series converges to <m>\frac{1}{1-1/2}.</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							The series converges, but its value cannot be determined.
+						</p>
+					</li>
+					<li>
+						<p>
+							The series diverges.
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The value of a painting, initially worth $10000, continuously grows in value at a rate of 4% a year. Let <m>y(t)</m> be the value of the painting after <m>t</m> years. Which of the following expressions correctly describe <m>y(t)</m>? Select all that apply.
+				</p>
+				<ul>
+					<li>
+						<p>
+							<m>y(t)= 10000e^{0.04t}</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>y(t)= 10000(1+0.04/n)^{nt}</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>y'(t) = 0.04(10000 -y).</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>y'(t) = 0.04y,</m> with <m>y(0) = 10000</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							None of the above.
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Consider the function <m>f(x,y) = e^{x-1}\sqrt{y -4}.</m> Then the domain of <m>f(x,y)</m> is given by:
+				</p>
+				<ul>
+					<li>
+						<p>
+							<m>\{ (x,y) | y \neq 4 \}</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>\{ (x,y) | x \neq 1\, \text{and } \, y \neq 4 \}</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>\{ (x,y) | y &gt; 4 \}</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>\{ (x,y) | y \ge 4 \}</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>\{ (x,y) | y \le 4 \}</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>\{ (x,y) | x \ge 1 \}</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>\{ (x,y) | x \le 1 \}</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							None of the above.
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+	</exercise>
+</worksheet>

--- a/source/math213-exams/Math213-FinalExam.ptx
+++ b/source/math213-exams/Math213-FinalExam.ptx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <worksheet xml:id="Math213-FinalExam" xmlns:xi="http://www.w3.org/2001/XInclude">
-	<title>Math213-FinalExam</title>
+	<title>Math 213 Final Exam Practice Exam</title>
 	<exercise>
 		<introduction>
 			<p>

--- a/source/math213-exams/Math213-FinalExam.ptx
+++ b/source/math213-exams/Math213-FinalExam.ptx
@@ -1,295 +1,202 @@
 <?xml version="1.0" encoding="utf-8"?>
 <worksheet xml:id="Math213-FinalExam" xmlns:xi="http://www.w3.org/2001/XInclude">
-	<title>Math213-FinalExam</title>
-	<exercise>
-		<introduction>
-			<p>
-				Consider the first-order linear differential equation <me>y' -\dfrac{3}{x}y = x^4.</me>
-			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Find the general solution of the differential equation.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find the particular solution that satisfies the initial condition <m>y(1) = 5.</m>
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				For your retirement <q>nest egg,</q> you deposit $300 at the end of each month into a bank account paying 6% interest compounded monthly. Use your knowledge of series to find an expression that represents the amount of this annuity at the end of your 40-year working career. While you do not need to simplify your final answer, you do need to find a single term expression that represents the value of the annuity. Writing your answer as a sum of terms is not enough.
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-					Find the 3rd degree Taylor polynomial of <m>f(x) = \sqrt{x}</m> centered at <m>x=9.</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Use the 3rd degree Taylor polynomial that you found in part (a) to find an approximation for <m>\sqrt{10}</m> by evaluating the polynomial at an appropriate value of <m>x.</m>
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Use known series expansions to find the Taylor Series of <m>f(x) = x^2 e^{2x}</m> centered at <m>x=0.</m> Give at least the first five terms of the series.
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Find the volume under the surface <m>f(x,y) = 4y</m> and above the shaded region <m>R</m> shown in the graph.
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Use the method of Lagrange multipliers to find the minimum of <m>f(x,y) = 4xy</m> subject to the constraint <m>2x+6y=12.</m>
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Consider the initial-value problem <me>y' = 2x + y, \,\, y(0) = 2.</me> Use Euler’s method with <m>n = 2</m> steps to approximate <m>y(1).</m>
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Consider the function <m>f(x) = x^2-x-2.</m> Use 2 iterations of Newton’s method starting with <m>x_0 = 1</m> to approximate a zero of <m>f(x).</m>
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Consider a continuous random variable <m>X</m> with probability density function <m>f(x) =
-							\dfrac{3}{2}\sqrt{x}</m> on <m>[0,1].</m>
-			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Compute the probability <m>P\left(X \ge \dfrac{1}{2} \right)</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find the mean (i.e., the expected value) of <m>X.</m>
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				For the spinner below, the arrow is spun and then stops, pointing in one of the numbered sectors, with probability proportional to the area of the sector. Let <m>X</m> stand for the number so chosen. Find the following. (Leave your answers as fractions, integers, or exact decimals.)
-			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					<m>P(X=8)=</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					<m>E(X)=</m>
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				A company’s profit <m>P(x,y)</m> from making <m>x</m> computers and <m>y</m> tablets per day is given by <m>P(x,y) = 4x^2-5xy +5y^2 +10x+4y+70.</m>
-			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Find the marginal profit function for computers.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find the marginal profit function for tablets.
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
-			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Consider the infinite series <m>\displaystyle\sum_{n=0}^{\infty}\dfrac{8}{6^n}.</m> What can you say about the convergence of this series?
-				</p>
-				<ul>
-					<li>
-						<p>
-							The series converges to <m>8/6.</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							The series converges to <m>\frac{8}{1-1/6}.</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							The series converges, but its value cannot be determined.
-						</p>
-					</li>
-					<li>
-						<p>
-							The series diverges.
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Consider the infinite series <m>\displaystyle\sum_{n=1}^{\infty}(-1)^{n-1}\dfrac{1}{n2^n}.</m> What can you say about the convergence of this series?
-				</p>
-				<ul>
-					<li>
-						<p>
-							The series converges to <m>\ln(3/2).</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							The series converges to <m>\frac{1}{1-1/2}.</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							The series converges, but its value cannot be determined.
-						</p>
-					</li>
-					<li>
-						<p>
-							The series diverges.
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					The value of a painting, initially worth $10000, continuously grows in value at a rate of 4% a year. Let <m>y(t)</m> be the value of the painting after <m>t</m> years. Which of the following expressions correctly describe <m>y(t)</m>? Select all that apply.
-				</p>
-				<ul>
-					<li>
-						<p>
-							<m>y(t)= 10000e^{0.04t}</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>y(t)= 10000(1+0.04/n)^{nt}</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>y'(t) = 0.04(10000 -y).</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>y'(t) = 0.04y,</m> with <m>y(0) = 10000</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							None of the above.
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Consider the function <m>f(x,y) = e^{x-1}\sqrt{y -4}.</m> Then the domain of <m>f(x,y)</m> is given by:
-				</p>
-				<ul>
-					<li>
-						<p>
-							<m>\{ (x,y) | y \neq 4 \}</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>\{ (x,y) | x \neq 1\, \text{and } \, y \neq 4 \}</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>\{ (x,y) | y &gt; 4 \}</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>\{ (x,y) | y \ge 4 \}</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>\{ (x,y) | y \le 4 \}</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>\{ (x,y) | x \ge 1 \}</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>\{ (x,y) | x \le 1 \}</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							None of the above.
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-	</exercise>
+  <title>Math213-FinalExam</title>
+  <exercise>
+    <introduction>
+      <p>Consider the first-order linear differential equation <me>y' -\dfrac{3}{x}y = x^4.</me></p>
+    </introduction>
+    <task>
+      <statement>
+        <p>Find the general solution of the differential equation.</p>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Find the particular solution that satisfies the initial condition <m>y(1) = 5.</m></p>
+      </statement>
+    </task>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>For your retirement <q>nest egg,</q> you deposit $300 at the end of each month into a bank account paying 6% interest compounded monthly. Use your knowledge of series to find an expression that represents the amount of this annuity at the end of your 40-year working career. While you do not need to simplify your final answer, you do need to find a single term expression that represents the value of the annuity. Writing your answer as a sum of terms is not enough.</p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <task>
+      <statement>
+        <p>Find the 3rd degree Taylor polynomial of <m>f(x) = \sqrt{x}</m> centered at <m>x=9.</m></p>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Use the 3rd degree Taylor polynomial that you found in part (a) to find an approximation for <m>\sqrt{10}</m> by evaluating the polynomial at an appropriate value of <m>x.</m></p>
+      </statement>
+    </task>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Use known series expansions to find the Taylor Series of <m>f(x) = x^2 e^{2x}</m> centered at <m>x=0.</m> Give at least the first five terms of the series.</p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Find the volume under the surface <m>f(x,y) = 4y</m> and above the shaded region <m>R</m> shown in the graph.</p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Use the method of Lagrange multipliers to find the minimum of <m>f(x,y) = 4xy</m> subject to the constraint <m>2x+6y=12.</m></p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Consider the initial-value problem <me>y' = 2x + y, \,\, y(0) = 2.</me> Use Euler’s method with <m>n = 2</m> steps to approximate <m>y(1).</m></p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Consider the function <m>f(x) = x^2-x-2.</m> Use 2 iterations of Newton’s method starting with <m>x_0 = 1</m> to approximate a zero of <m>f(x).</m></p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Consider a continuous random variable <m>X</m> with probability density function <m>f(x) = \dfrac{3}{2}\sqrt{x}</m> on <m>[0,1].</m></p>
+    </introduction>
+    <task>
+      <statement>
+        <p>Compute the probability <m>P\left(X \ge \dfrac{1}{2} \right)</m></p>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Find the mean (i.e., the expected value) of <m>X.</m></p>
+      </statement>
+    </task>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>For the spinner below, the arrow is spun and then stops, pointing in one of the numbered sectors, with probability proportional to the area of the sector. Let <m>X</m> stand for the number so chosen. Find the following. (Leave your answers as fractions, integers, or exact decimals.)</p>
+    </introduction>
+    <task>
+      <statement>
+        <p><m>P(X=8)=</m></p>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p><m>E(X)=</m></p>
+      </statement>
+    </task>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>A company’s profit <m>P(x,y)</m> from making <m>x</m> computers and <m>y</m> tablets per day is given by <m>P(x,y) = 4x^2-5xy +5y^2 +10x+4y+70.</m></p>
+    </introduction>
+    <task>
+      <statement>
+        <p>Find the marginal profit function for computers.</p>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Find the marginal profit function for tablets.</p>
+      </statement>
+    </task>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term></p>
+    </introduction>
+    <task>
+      <statement>
+        <p>Consider the infinite series <m>\displaystyle\sum_{n=0}^{\infty}\dfrac{8}{6^n}.</m> What can you say about the convergence of this series?</p>
+        <ul>
+          <li>
+            <p>The series converges to <m>8/6.</m></p>
+          </li>
+          <li>
+            <p>The series converges to <m>\frac{8}{1-1/6}.</m></p>
+          </li>
+          <li>
+            <p>The series converges, but its value cannot be determined.</p>
+          </li>
+          <li>
+            <p>The series diverges.</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Consider the infinite series <m>\displaystyle\sum_{n=1}^{\infty}(-1)^{n-1}\dfrac{1}{n2^n}.</m> What can you say about the convergence of this series?</p>
+        <ul>
+          <li>
+            <p>The series converges to <m>\ln(3/2).</m></p>
+          </li>
+          <li>
+            <p>The series converges to <m>\frac{1}{1-1/2}.</m></p>
+          </li>
+          <li>
+            <p>The series converges, but its value cannot be determined.</p>
+          </li>
+          <li>
+            <p>The series diverges.</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>The value of a painting, initially worth $10000, continuously grows in value at a rate of 4% a year. Let <m>y(t)</m> be the value of the painting after <m>t</m> years. Which of the following expressions correctly describe <m>y(t)</m>? Select all that apply.</p>
+        <ul>
+          <li>
+            <p><m>y(t)= 10000e^{0.04t}</m></p>
+          </li>
+          <li>
+            <p><m>y(t)= 10000(1+0.04/n)^{nt}</m></p>
+          </li>
+          <li>
+            <p><m>y'(t) = 0.04(10000 -y).</m></p>
+          </li>
+          <li>
+            <p><m>y'(t) = 0.04y,</m> with <m>y(0) = 10000</m></p>
+          </li>
+          <li>
+            <p>None of the above.</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Consider the function <m>f(x,y) = e^{x-1}\sqrt{y -4}.</m> Then the domain of <m>f(x,y)</m> is given by:</p>
+        <ul>
+          <li>
+            <p><m>\{ (x,y) | y \neq 4 \}</m></p>
+          </li>
+          <li>
+            <p><m>\{ (x,y) | x \neq 1\, \text{and } \, y \neq 4 \}</m></p>
+          </li>
+          <li>
+            <p><m>\{ (x,y) | y &gt; 4 \}</m></p>
+          </li>
+          <li>
+            <p><m>\{ (x,y) | y \ge 4 \}</m></p>
+          </li>
+          <li>
+            <p><m>\{ (x,y) | y \le 4 \}</m></p>
+          </li>
+          <li>
+            <p><m>\{ (x,y) | x \ge 1 \}</m></p>
+          </li>
+          <li>
+            <p><m>\{ (x,y) | x \le 1 \}</m></p>
+          </li>
+          <li>
+            <p>None of the above.</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+  </exercise>
 </worksheet>

--- a/source/math213-exams/Math213-FinalExam.tex
+++ b/source/math213-exams/Math213-FinalExam.tex
@@ -19,7 +19,6 @@ expression that represents the amount of this annuity at the end of your 40-year
 While you do not need to simplify your final answer, you do need to find a single term
 expression that represents the value of the annuity. Writing your answer as a sum of terms is
 not enough.
-%sec 10.2
 \newpage
 \question
 \begin{parts}
@@ -35,8 +34,6 @@ centered at $x=0.$ Give at least the first five terms of the series.
 \newpage
 \question[8] Find the volume under the surface $f(x,y) = 4y$ and above the shaded region $R$
 shown in the graph.
-%Note to Kailtyn: can you help me with a picture of the region between xsquared and sqrtx?
-%-Done.
 
 \begin{tikzpicture}
 \begin{axis}[
@@ -55,8 +52,6 @@ xtick distance=1, ytick distance=1, grid=both ]
 {sqrt(x)} node[pos=1, right]{$y=\sqrt{x}$};;
 \addplot [domain=0:1.3, samples=100,->, name path=g, thick]
 {x^2} node[pos=1, above]{$y=x^2$};
-%\node[font=\footnotesize] at (axis cs: 2,1.5) {$y=f(x)$};
-%\node[ font=\footnotesize] at (axis cs: 1.5,2.2) {$y=g(x)$};
 \addplot[gray!50, opacity=0.4] fill between[of=f and g, soft clip={domain=-1:1}];
 \node at (axis cs:0.5, 0.5) {$R$};
 
@@ -96,7 +91,6 @@ decimals.)
 \draw[fill=none,thick](0,0) circle (2.0);
 \draw[](-2,0) -- (2,0);
 \draw[] (0,0) --(0,2);
-%\draw[-{Triangle[width=16pt,length=10pt]}, line width=8pt](-1.5, -0.5) -- (1.5, 0.5);
 \draw[fill=black, rotate=20]
 (-1.7,0.15)--(-1.6,0)--(-1.7,-0.15)--(1.5,-0.15)--(1.5,-0.3)--(1.75,0)--(1.5,0.3)--(1.5,0.15)--cycle;
 \draw[fill=white](0,0) circle (2 pt);
@@ -112,13 +106,6 @@ decimals.)
 \vfill
 
 \end{parts}
-%Consider the experiment of rolling two fair 6-sided dice.
-%\begin{parts}
-%\part[3] Determine the probability that the sum of the numbers rolled is 10.
-%\vfill
-%\part[3] Determine the probability that a 1 is rolled on either die.
-%\vfill
-%\end{parts}
 
 \newpage
 
@@ -145,8 +132,6 @@ you say about the convergence of this series?
 \item \chooseone The series converges to $\frac{8}{1-1/6}.$
 \item \chooseone The series converges, but its value cannot be determined.
 \item \chooseone The series diverges.
-%\item \chooseone It cannot be determined whether the series converges or diverges with the
-%given information.
 \end{itemize}
 \vfill
 \part[2] Consider the infinite series $\displaystyle\sum_{n=1}^{\infty}(-1)^{n-1}\dfrac{1}{n2^n}.$
@@ -156,8 +141,6 @@ What can you say about the convergence of this series?
 \item \chooseone The series converges to $\frac{1}{1-1/2}.$
 \item \chooseone The series converges, but its value cannot be determined.
 \item \chooseone The series diverges.
-%\item \chooseone It cannot be determined whether the series converges or diverges with the
-%given information.
 \end{itemize}
 \vfill
 

--- a/source/math213-exams/Math213-FinalExam.tex
+++ b/source/math213-exams/Math213-FinalExam.tex
@@ -14,11 +14,10 @@ $$y' -\dfrac{3}{x}y = x^4.$$
 
 \question[8] For your retirement ``nest egg,'' you deposit \$300 at the end of each month into a
 bank account paying 6\% interest compounded monthly. Use your knowledge of series to find an
-
 expression that represents the amount of this annuity at the end of your 40-year working career.
 While you do not need to simplify your final answer, you do need to find a single term
-expression that represents the value of the annuity. Writing your answer as a sum of terms is
-not enough.
+expression that represents the value of the annuity. Writing your answer as a sum of terms is not
+enough.
 \newpage
 \question
 \begin{parts}

--- a/source/math213-exams/Math213-Midterm1.ptx
+++ b/source/math213-exams/Math213-Midterm1.ptx
@@ -1,346 +1,234 @@
 <?xml version="1.0" encoding="utf-8"?>
 <worksheet xml:id="Math213-Midterm1" xmlns:xi="http://www.w3.org/2001/XInclude">
-	<title>Math213-Midterm1</title>
-	<exercise>
-		<introduction>
-			<p>
-				Find the solution to the differential equation <me>\dfrac{dy}{dx} = e^{x+y},</me> with initial condition <m>y(0) = 1.</m> You do not need to solve for <m>y</m> in your final expression.
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Find the general solution to the differential equation <me>\dfrac{dy}{dx} - \dfrac{4}{x}y = x^2+1.</me> You do not need to solve for <m>y</m> in your final expression.
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Suppose the population of a certain species is modeled by the differential equation <me>\dfrac{dP}{dt} = 1.4P(7200-P).</me> You do NOT need to show work to receive full credit on this problem.
-			</p>
-			<hint>
-			        <p>
-			                You do NOT need to solve the differential equation to answer this question.
-			        </p>
-			</hint>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Determine what type of differential equation is the differential equation given above. Clearly mark the correct answer by completely filling in the appropriate bubble.
-				</p>
-				<ul>
-					<li>
-						<p>
-							Unlimited growth
-						</p>
-					</li>
-					<li>
-						<p>
-							Logistic growth
-						</p>
-					</li>
-					<li>
-						<p>
-							Limited growth
-						</p>
-					</li>
-					<li>
-						<p>
-							None of the above
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					If <m>P(0) = 8000,</m> what is the value of <m>\displaystyle\lim_{t \to \infty} P(t)</m>?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					If <m>P(0) = 100,</m> what is the value of <m>\displaystyle \lim_{t \to \infty} P(t)</m>?
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				A tennis player expects his career to last 15 years, and for his retirement deposits $6000 at the end of each month in a bank account earning 3% interest compounded monthly.
-			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Write down an expression (finite sum) that represents the amount of this annuity at the end of 15 years. Your expression should include at least the first 2 terms and the last 2 terms.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					The expression you found in part (a) represents the partial sum of a geometric series. Use your knowledge of geometric series to obtain a simplified expression for the value of the annuity at the end of 15 years. You can leave your answer as a quotient.
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Find the 4th degree Taylor polynomial for <m>f(x) = e^x</m> centered at <m>1.</m>
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Find the 3rd degree polynomial for <m>f(x) = \ln(x+e)</m> centered at <m>0.</m>
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Examine the convergence of the geometric series <m>5 + -10 + 20 + -40 + \ldots</m>. If it converges, determine its sum. Otherwise, provide a justification for its divergence.
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-					Find the sum of the geometric series <m>\displaystyle\sum_{n=0}^{\infty} 4 \left(\dfrac{1}{3} \right)^n</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What is the ratio of the infinite geometric series <m>5 + \dfrac{1}{5} + \ldots</m>? Does the series converge?
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
-			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					The value of a home, originally worth $450,000, grows continuously at a rate of 3%. Choose the initial value problem that describes the value <m>y(t)</m> of the home at time <m>t.</m>
-				</p>
-				<ul>
-					<li>
-						<p>
-							<m>y' -0.03y = 450000</m> with <m>y(0) = 450000</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>y' = 0.03(y-450000)</m> with <m>y(0) = 0</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>y' = 0.03y</m> with <m>y(0) = 450000</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>y' = 1.03y</m> with <m>y(0) = 450000</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							None of the above
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Suppose the slope field below correspond to the population of trout in a lake (where <m>y</m> is the population in hundreds and <m>x</m> is months). For which <m>y</m> values is the population of trout increasing? <image source='dirfield.png'/>
-				</p>
-				<ul>
-					<li>
-						<p>
-							<m>y=0,4</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>0&lt;y&lt;4</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>y&gt;4</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							All <m>y</m> values
-						</p>
-					</li>
-					<li>
-						<p>
-							None of the above
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Which of the following are solutions to <m>y' = 4y+ 8</m> ? Select all that apply.
-				</p>
-				<ul>
-					<li>
-						<p>
-							<m>y = e^{-4x} - 2</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>y = 3e^{4x} - 2</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>y = -2</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							All of the above
-						</p>
-					</li>
-					<li>
-						<p>
-							None of the above
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					The differential equation <m>(y+1)\dfrac{dy}{dx} = xy + e^xy</m> is separable.
-				</p>
-				<ul>
-					<li>
-						<p>
-							True
-						</p>
-					</li>
-					<li>
-						<p>
-							False
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					The differential equation <m>x\dfrac{dy}{dx} = y + 4x^2 - 5</m> is linear.
-				</p>
-				<ul>
-					<li>
-						<p>
-							True
-						</p>
-					</li>
-					<li>
-						<p>
-							False
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Determine the type of the differential equation <m>\dfrac{dA}{dt} = 0.4(800-A)</m>
-				</p>
-				<ul>
-					<li>
-						<p>
-							Unlimited growth
-						</p>
-					</li>
-					<li>
-						<p>
-							Logistic growth
-						</p>
-					</li>
-					<li>
-						<p>
-							Limited growth
-						</p>
-					</li>
-					<li>
-						<p>
-							None of the above
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Which of the following series are convergent? Select all that apply.
-				</p>
-				<ul>
-					<li>
-						<p>
-							<m>\displaystyle\sum_{n=0}^{\infty} \dfrac{4}{2^n}</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>\displaystyle\sum_{n=0}^{\infty} (0.3)^n</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>\displaystyle\sum_{n=0}^{\infty} \dfrac{1}{3}(1.2)^n</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							<m>\displaystyle\sum_{n=0}^{\infty} 6^{-n}</m>
-						</p>
-					</li>
-					<li>
-						<p>
-							All of the above
-						</p>
-					</li>
-					<li>
-						<p>
-							None of the above
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-	</exercise>
+  <title>Math213-Midterm1</title>
+  <exercise>
+    <introduction>
+      <p>Find the solution to the differential equation <me>\dfrac{dy}{dx} = e^{x+y},</me> with initial condition <m>y(0) = 1.</m> You do not need to solve for <m>y</m> in your final expression.</p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Find the general solution to the differential equation <me>\dfrac{dy}{dx} - \dfrac{4}{x}y = x^2+1.</me> You do not need to solve for <m>y</m> in your final expression.</p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Suppose the population of a certain species is modeled by the differential equation <me>\dfrac{dP}{dt} = 1.4P(7200-P).</me> You do NOT need to show work to receive full credit on this problem.</p>
+      <hint>
+        <p>You do NOT need to solve the differential equation to answer this question.</p>
+      </hint>
+    </introduction>
+    <task>
+      <statement>
+        <p>Determine what type of differential equation is the differential equation given above. Clearly mark the correct answer by completely filling in the appropriate bubble.</p>
+        <ul>
+          <li>
+            <p>Unlimited growth</p>
+          </li>
+          <li>
+            <p>Logistic growth</p>
+          </li>
+          <li>
+            <p>Limited growth</p>
+          </li>
+          <li>
+            <p>None of the above</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>If <m>P(0) = 8000,</m> what is the value of <m>\displaystyle\lim_{t \to \infty} P(t)</m>?</p>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>If <m>P(0) = 100,</m> what is the value of <m>\displaystyle \lim_{t \to \infty} P(t)</m>?</p>
+      </statement>
+    </task>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>A tennis player expects his career to last 15 years, and for his retirement deposits $6000 at the end of each month in a bank account earning 3% interest compounded monthly.</p>
+    </introduction>
+    <task>
+      <statement>
+        <p>Write down an expression (finite sum) that represents the amount of this annuity at the end of 15 years. Your expression should include at least the first 2 terms and the last 2 terms.</p>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>The expression you found in part (a) represents the partial sum of a geometric series. Use your knowledge of geometric series to obtain a simplified expression for the value of the annuity at the end of 15 years. You can leave your answer as a quotient.</p>
+      </statement>
+    </task>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Find the 4th degree Taylor polynomial for <m>f(x) = e^x</m> centered at <m>1.</m></p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Find the 3rd degree polynomial for <m>f(x) = \ln(x+e)</m> centered at <m>0.</m></p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Examine the convergence of the geometric series <m>5 + -10 + 20 + -40 + \ldots</m>. If it converges, determine its sum. Otherwise, provide a justification for its divergence.</p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <task>
+      <statement>
+        <p>Find the sum of the geometric series <m>\displaystyle\sum_{n=0}^{\infty} 4 \left(\dfrac{1}{3} \right)^n</m></p>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>What is the ratio of the infinite geometric series <m>5 + \dfrac{1}{5} + \ldots</m>? Does the series converge?</p>
+      </statement>
+    </task>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term></p>
+    </introduction>
+    <task>
+      <statement>
+        <p>The value of a home, originally worth $450,000, grows continuously at a rate of 3%. Choose the initial value problem that describes the value <m>y(t)</m> of the home at time <m>t.</m></p>
+        <ul>
+          <li>
+            <p><m>y' -0.03y = 450000</m> with <m>y(0) = 450000</m></p>
+          </li>
+          <li>
+            <p><m>y' = 0.03(y-450000)</m> with <m>y(0) = 0</m></p>
+          </li>
+          <li>
+            <p><m>y' = 0.03y</m> with <m>y(0) = 450000</m></p>
+          </li>
+          <li>
+            <p><m>y' = 1.03y</m> with <m>y(0) = 450000</m></p>
+          </li>
+          <li>
+            <p>None of the above</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Suppose the slope field below correspond to the population of trout in a lake (where <m>y</m> is the population in hundreds and <m>x</m> is months). For which <m>y</m> values is the population of trout increasing? <image source="dirfield.png" /></p>
+        <ul>
+          <li>
+            <p><m>y=0,4</m></p>
+          </li>
+          <li>
+            <p><m>0&lt;y&lt;4</m></p>
+          </li>
+          <li>
+            <p><m>y&gt;4</m></p>
+          </li>
+          <li>
+            <p>All <m>y</m> values</p>
+          </li>
+          <li>
+            <p>None of the above</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Which of the following are solutions to <m>y' = 4y+ 8</m> ? Select all that apply.</p>
+        <ul>
+          <li>
+            <p><m>y = e^{-4x} - 2</m></p>
+          </li>
+          <li>
+            <p><m>y = 3e^{4x} - 2</m></p>
+          </li>
+          <li>
+            <p><m>y = -2</m></p>
+          </li>
+          <li>
+            <p>All of the above</p>
+          </li>
+          <li>
+            <p>None of the above</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>The differential equation <m>(y+1)\dfrac{dy}{dx} = xy + e^xy</m> is separable.</p>
+        <ul>
+          <li>
+            <p>True</p>
+          </li>
+          <li>
+            <p>False</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>The differential equation <m>x\dfrac{dy}{dx} = y + 4x^2 - 5</m> is linear.</p>
+        <ul>
+          <li>
+            <p>True</p>
+          </li>
+          <li>
+            <p>False</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Determine the type of the differential equation <m>\dfrac{dA}{dt} = 0.4(800-A)</m></p>
+        <ul>
+          <li>
+            <p>Unlimited growth</p>
+          </li>
+          <li>
+            <p>Logistic growth</p>
+          </li>
+          <li>
+            <p>Limited growth</p>
+          </li>
+          <li>
+            <p>None of the above</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Which of the following series are convergent? Select all that apply.</p>
+        <ul>
+          <li>
+            <p><m>\displaystyle\sum_{n=0}^{\infty} \dfrac{4}{2^n}</m></p>
+          </li>
+          <li>
+            <p><m>\displaystyle\sum_{n=0}^{\infty} (0.3)^n</m></p>
+          </li>
+          <li>
+            <p><m>\displaystyle\sum_{n=0}^{\infty} \dfrac{1}{3}(1.2)^n</m></p>
+          </li>
+          <li>
+            <p><m>\displaystyle\sum_{n=0}^{\infty} 6^{-n}</m></p>
+          </li>
+          <li>
+            <p>All of the above</p>
+          </li>
+          <li>
+            <p>None of the above</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+  </exercise>
 </worksheet>

--- a/source/math213-exams/Math213-Midterm1.ptx
+++ b/source/math213-exams/Math213-Midterm1.ptx
@@ -14,11 +14,11 @@
   <exercise>
     <introduction>
       <p>Suppose the population of a certain species is modeled by the differential equation <me>\dfrac{dP}{dt} = 1.4P(7200-P).</me> You do NOT need to show work to receive full credit on this problem.</p>
+    </introduction>
+    <task>
       <hint>
         <p>You do NOT need to solve the differential equation to answer this question.</p>
       </hint>
-    </introduction>
-    <task>
       <statement>
         <p>Determine what type of differential equation is the differential equation given above. Clearly mark the correct answer by completely filling in the appropriate bubble.</p>
         <ul>

--- a/source/math213-exams/Math213-Midterm1.ptx
+++ b/source/math213-exams/Math213-Midterm1.ptx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <worksheet xml:id="Math213-Midterm1" xmlns:xi="http://www.w3.org/2001/XInclude">
-	<title>Math213-Midterm1</title>
+	<title>Math 213 Midterm 1 Practice Exam</title>
 	<exercise>
 		<introduction>
 			<p>

--- a/source/math213-exams/Math213-Midterm1.ptx
+++ b/source/math213-exams/Math213-Midterm1.ptx
@@ -1,7 +1,346 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<section xml:id="math213-midterm1" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <title>Math 213 Midterm 1 Practice Exam</title>
-  <raw format="latex" xml:space="preserve">
-    <xi:include href="./Math213-Midterm1.tex" parse="text"/>
-  </raw>
-</section>
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Math213-Midterm1" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Math213-Midterm1</title>
+	<exercise>
+		<introduction>
+			<p>
+				Find the solution to the differential equation <me>\dfrac{dy}{dx} = e^{x+y},</me> with initial condition <m>y(0) = 1.</m> You do not need to solve for <m>y</m> in your final expression.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the general solution to the differential equation <me>\dfrac{dy}{dx} - \dfrac{4}{x}y = x^2+1.</me> You do not need to solve for <m>y</m> in your final expression.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Suppose the population of a certain species is modeled by the differential equation <me>\dfrac{dP}{dt} = 1.4P(7200-P).</me> You do NOT need to show work to receive full credit on this problem.
+			</p>
+			<hint>
+			        <p>
+			                You do NOT need to solve the differential equation to answer this question.
+			        </p>
+			</hint>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Determine what type of differential equation is the differential equation given above. Clearly mark the correct answer by completely filling in the appropriate bubble.
+				</p>
+				<ul>
+					<li>
+						<p>
+							Unlimited growth
+						</p>
+					</li>
+					<li>
+						<p>
+							Logistic growth
+						</p>
+					</li>
+					<li>
+						<p>
+							Limited growth
+						</p>
+					</li>
+					<li>
+						<p>
+							None of the above
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					If <m>P(0) = 8000,</m> what is the value of <m>\displaystyle\lim_{t \to \infty} P(t)</m>?
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					If <m>P(0) = 100,</m> what is the value of <m>\displaystyle \lim_{t \to \infty} P(t)</m>?
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				A tennis player expects his career to last 15 years, and for his retirement deposits $6000 at the end of each month in a bank account earning 3% interest compounded monthly.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Write down an expression (finite sum) that represents the amount of this annuity at the end of 15 years. Your expression should include at least the first 2 terms and the last 2 terms.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The expression you found in part (a) represents the partial sum of a geometric series. Use your knowledge of geometric series to obtain a simplified expression for the value of the annuity at the end of 15 years. You can leave your answer as a quotient.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the 4th degree Taylor polynomial for <m>f(x) = e^x</m> centered at <m>1.</m>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the 3rd degree polynomial for <m>f(x) = \ln(x+e)</m> centered at <m>0.</m>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Examine the convergence of the geometric series <m>5 + -10 + 20 + -40 + \ldots</m>. If it converges, determine its sum. Otherwise, provide a justification for its divergence.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<task>
+			<statement>
+				<p>
+					Find the sum of the geometric series <m>\displaystyle\sum_{n=0}^{\infty} 4 \left(\dfrac{1}{3} \right)^n</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					What is the ratio of the infinite geometric series <m>5 + \dfrac{1}{5} + \ldots</m>? Does the series converge?
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					The value of a home, originally worth $450,000, grows continuously at a rate of 3%. Choose the initial value problem that describes the value <m>y(t)</m> of the home at time <m>t.</m>
+				</p>
+				<ul>
+					<li>
+						<p>
+							<m>y' -0.03y = 450000</m> with <m>y(0) = 450000</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>y' = 0.03(y-450000)</m> with <m>y(0) = 0</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>y' = 0.03y</m> with <m>y(0) = 450000</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>y' = 1.03y</m> with <m>y(0) = 450000</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							None of the above
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Suppose the slope field below correspond to the population of trout in a lake (where <m>y</m> is the population in hundreds and <m>x</m> is months). For which <m>y</m> values is the population of trout increasing? <image source='dirfield.png'/>
+				</p>
+				<ul>
+					<li>
+						<p>
+							<m>y=0,4</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>0&lt;y&lt;4</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>y&gt;4</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							All <m>y</m> values
+						</p>
+					</li>
+					<li>
+						<p>
+							None of the above
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Which of the following are solutions to <m>y' = 4y+ 8</m> ? Select all that apply.
+				</p>
+				<ul>
+					<li>
+						<p>
+							<m>y = e^{-4x} - 2</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>y = 3e^{4x} - 2</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>y = -2</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							All of the above
+						</p>
+					</li>
+					<li>
+						<p>
+							None of the above
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The differential equation <m>(y+1)\dfrac{dy}{dx} = xy + e^xy</m> is separable.
+				</p>
+				<ul>
+					<li>
+						<p>
+							True
+						</p>
+					</li>
+					<li>
+						<p>
+							False
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The differential equation <m>x\dfrac{dy}{dx} = y + 4x^2 - 5</m> is linear.
+				</p>
+				<ul>
+					<li>
+						<p>
+							True
+						</p>
+					</li>
+					<li>
+						<p>
+							False
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Determine the type of the differential equation <m>\dfrac{dA}{dt} = 0.4(800-A)</m>
+				</p>
+				<ul>
+					<li>
+						<p>
+							Unlimited growth
+						</p>
+					</li>
+					<li>
+						<p>
+							Logistic growth
+						</p>
+					</li>
+					<li>
+						<p>
+							Limited growth
+						</p>
+					</li>
+					<li>
+						<p>
+							None of the above
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Which of the following series are convergent? Select all that apply.
+				</p>
+				<ul>
+					<li>
+						<p>
+							<m>\displaystyle\sum_{n=0}^{\infty} \dfrac{4}{2^n}</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>\displaystyle\sum_{n=0}^{\infty} (0.3)^n</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>\displaystyle\sum_{n=0}^{\infty} \dfrac{1}{3}(1.2)^n</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							<m>\displaystyle\sum_{n=0}^{\infty} 6^{-n}</m>
+						</p>
+					</li>
+					<li>
+						<p>
+							All of the above
+						</p>
+					</li>
+					<li>
+						<p>
+							None of the above
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+	</exercise>
+</worksheet>

--- a/source/math213-exams/Math213-Midterm1.tex
+++ b/source/math213-exams/Math213-Midterm1.tex
@@ -24,30 +24,10 @@ Clearly mark the correct answer by completely filling in the appropriate bubble.
 \item \chooseone None of the above
 \end{itemize}
 \bigskip
-%\part[3] If the population at a certain time is 300, is the population increasing or decreasing at
-%that point? Clearly mark the correct answer by completely filling in the appropriate bubble.
 
-%\begin{itemize}[label={}]
-%\item \chooseone increasing
-%\item \chooseone decreasing
-%\item \chooseone stable (neither increasing nor decreasing)
-%\item \chooseone cannot be determined
-%\end{itemize}
-%\vfill
-%\part[3] If the population at a certain time is 9000, is the population increasing or decreasing at
-%that point? Clearly mark the correct answer by completely filling in the appropriate bubble.
-%\begin{itemize}[label={}]
-%\item \chooseone increasing
-%\item \chooseone decreasing
-%\item \chooseone stable (neither increasing nor decreasing)
-%\item \chooseone cannot be determined
-%\end{itemize}
-%\vfill
 
 \part[3] If $P(0) = 8000,$ what is the value of $\displaystyle\lim_{t \to \infty} P(t)$?
 \vfill
-%8/80 = 1+c
-%$y' =ay(M-y)$ with $y(0) = \dfrac{M}{1+c}.$ Its solution is
 \part[3] If $P(0) = 100,$ what is the value of $\displaystyle \lim_{t \to \infty} P(t)$?
 \vfill
 \end{parts}
@@ -64,21 +44,14 @@ annuity at the end of 15 years. You can leave your answer as a quotient.
 \vfill
 
 \end{parts}
-% like problem 50 in section 10.1
 
 \newpage
 \question[10] Find the 4th degree Taylor polynomial for $f(x) = e^x$ centered at $1.$
 
 \newpage
 \question[10]
-%\begin{parts}
 Find the 3rd degree polynomial for $f(x) = \ln(x+e)$ centered at $0.$
 \vfill
-%\part Use the 3rd degree Taylor polynomial for $f(x) = \ln(x+e)$ centered at 0 to approximate
-%the value of
-%$$\displaystyle\int_0^1 \ln(x+e)\, dx.$$
-%\vfill
-%\end{parts}
 \newpage
 \question[8] Examine the convergence of the geometric series $5 + -10 + 20 + -40 + \ldots$. If it
 converges, determine its sum. Otherwise, provide a justification for its divergence.
@@ -93,9 +66,6 @@ $\displaystyle\sum_{n=0}^{\infty} 4 \left(\dfrac{1}{3} \right)^n$
 \part[5] What is the ratio of the infinite geometric series $ 5 + \dfrac{1}{5} + \ldots $? Does the
 series converge?
 \vfill
-%\part[4] An infinite series $a_1+a_2 +a_3 + \ldots$ is such that $a_1 + a_2 + a_3 + \cdots +
-%a_N = \dfrac{2N}{3N-1}.$ Find the sum of the infinite series.
-%\vfill
 \end{parts}
 \newpage
 \question Clearly mark the correct answer for each of the following by completely filling in the
@@ -126,7 +96,6 @@ increasing?
 \item \chooseone None of the above
 \end{itemize}
 
-%problem 46 in sec 9.3
 \vfill
 
 \part[4] Which of the following are solutions to $y' = 4y+ 8$ ? Select all that apply.

--- a/source/math213-exams/Math213-Midterm2.ptx
+++ b/source/math213-exams/Math213-Midterm2.ptx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <worksheet xml:id="Math213-Midterm2" xmlns:xi="http://www.w3.org/2001/XInclude">
-	<title>Math213-Midterm2</title>
+<title>Math 213 Midterm 2 Practice Exam</title>
 	<exercise>
 		<introduction>
 			<p>

--- a/source/math213-exams/Math213-Midterm2.ptx
+++ b/source/math213-exams/Math213-Midterm2.ptx
@@ -1,7 +1,217 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<section xml:id="math213-midterm2" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <title>Math 213 Midterm 2 Practice Exam</title>
-  <raw format="latex" xml:space="preserve">
-    <xi:include href="./Math213-Midterm2.tex" parse="text"/>
-  </raw>
-</section>
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Math213-Midterm2" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Math213-Midterm2</title>
+	<exercise>
+		<introduction>
+			<p>
+				Determine the radius of convergence for the power series <m>\displaystyle\sum_{n=1}^{\infty}
+							\dfrac{n^2 x^n}{2^n}</m>.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Modify a known series expansion to find the Taylor Series for <m>f(x) =
+							\dfrac{x^2}{1+5x}</m> centered at 0. Please provide at least the first 5 terms of the series. You do not need to provide a formula for the general term.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				A company produces violins and cellos. If they price the violins at <m>x</m> dollars and the cellos at <m>y</m> dollars, they sell <m>200-2x+3y</m> violins a day and <m>300+x-4y</m> cellos a day.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find their revenue function <m>R(x,y)</m>.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					If it costs <m>\$100</m> to produce a violin and <m>\$200</m> to produce a cello, with daily fixed costs at <m>\$500</m>, find their profit function <m>P(x,y)</m>.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<task>
+			<statement>
+				<p>
+					Compute <m>\displaystyle\int_0^1\int_{x^2}^{\sqrt{x}}2xy\, dy\, dx</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Set up, but do not solve, a double integral that represents the volume under the surface <m>f(x,y) = x^2e^{xy}</m> and above the shaded region <m>R</m> bounded by <m>f(x)=x</m> and <m>g(x)=x^3</m> shown in the graph below.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the critical points of the function <m>f(x, y) = x^2 + 8xy + 4y^2 + 16x - 8y + 1.</m>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For the function <m>f(x,y)=\frac{1}{3}y^3-y +x^2y</m>:
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Compute <m>f_{xx}, f_{yy},</m> and <m>f_{xy}</m>. Show all work.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					The critical points of <m>f(x,y)</m> are <m>(0,1),</m> <m>(0,-1),</m> <m>(-1,0)</m> and <m>(1,0)</m>. Determine, using the <m>D</m>-test, if each point corresponds to a relative maximum, relative minimum, or saddle point. Show all work.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Use Lagrange multipliers to find the absolute maximum and the absolute minimum of <m>f(x, y) = x+4y</m> on the ellipse <m>x^2 + 2y^2 = 36.</m>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Short answer questions. You do not need to justify your answer or show your work.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find the value of the infinite series <m>1 + 2 + \dfrac{2^2}{2!} + \dfrac{2^3}{3!} +
+											\dfrac{2^4}{4!}+\ldots</m>.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the domain of the function <m>f(x,y) = \ln(x - 3)\sqrt{y}.</m> Write your answer using set notation.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Let <m>y = x^3-x^2+1.</m> Find <m>dy</m> if <m>x=2</m> and <m>dx = 1/2.</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					A company’s profit from producing <m>x</m> chairs and <m>y</m> tables per day is <m>P(x,y)</m>. Assume <m>P_y(46, 53) = 86.</m> Which of the following statements can we deduce from the provided information?
+				</p>
+				<ul>
+					<li>
+						<p>
+							Profit increases by about $86 per additional chair when producing 46 chairs and 53 tables per day.
+						</p>
+					</li>
+					<li>
+						<p>
+							Profit increases by about $86 per additional table when producing 46 chairs and 53 tables per day.
+						</p>
+					</li>
+					<li>
+						<p>
+							Profit is constant and equals $86, independent of how many chairs and/or tables are produced.
+						</p>
+					</li>
+					<li>
+						<p>
+							None of the above
+						</p>
+					</li>
+					<li>
+						<p>
+							All of the above
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Using the least squares method, the slope of the best-fit line for data points (1, 1), (2, 2), and (3, 4) is:
+				</p>
+				<ul>
+					<li>
+					</li>
+					<li>
+					</li>
+					<li>
+					</li>
+					<li>
+					</li>
+				</ul>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Every function <m>f(x,y)</m> of two variables can be written as the sum of two functions of one variable, <m>g(x)+h(y).</m>
+				</p>
+				<ul>
+					<li>
+						<p>
+							True
+						</p>
+					</li>
+					<li>
+						<p>
+							False
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					At a critical point, <m>D=0</m> means that the point is <em>not</em> a relative maximum or minimum point.
+				</p>
+				<ul>
+					<li>
+						<p>
+							True
+						</p>
+					</li>
+					<li>
+						<p>
+							False
+						</p>
+					</li>
+				</ul>
+			</statement>
+		</task>
+	</exercise>
+</worksheet>

--- a/source/math213-exams/Math213-Midterm2.ptx
+++ b/source/math213-exams/Math213-Midterm2.ptx
@@ -1,217 +1,154 @@
 <?xml version="1.0" encoding="utf-8"?>
 <worksheet xml:id="Math213-Midterm2" xmlns:xi="http://www.w3.org/2001/XInclude">
-	<title>Math213-Midterm2</title>
-	<exercise>
-		<introduction>
-			<p>
-				Determine the radius of convergence for the power series <m>\displaystyle\sum_{n=1}^{\infty}
-							\dfrac{n^2 x^n}{2^n}</m>.
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Modify a known series expansion to find the Taylor Series for <m>f(x) =
-							\dfrac{x^2}{1+5x}</m> centered at 0. Please provide at least the first 5 terms of the series. You do not need to provide a formula for the general term.
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				A company produces violins and cellos. If they price the violins at <m>x</m> dollars and the cellos at <m>y</m> dollars, they sell <m>200-2x+3y</m> violins a day and <m>300+x-4y</m> cellos a day.
-			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Find their revenue function <m>R(x,y)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					If it costs <m>\$100</m> to produce a violin and <m>\$200</m> to produce a cello, with daily fixed costs at <m>\$500</m>, find their profit function <m>P(x,y)</m>.
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-					Compute <m>\displaystyle\int_0^1\int_{x^2}^{\sqrt{x}}2xy\, dy\, dx</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Set up, but do not solve, a double integral that represents the volume under the surface <m>f(x,y) = x^2e^{xy}</m> and above the shaded region <m>R</m> bounded by <m>f(x)=x</m> and <m>g(x)=x^3</m> shown in the graph below.
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Find the critical points of the function <m>f(x, y) = x^2 + 8xy + 4y^2 + 16x - 8y + 1.</m>
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				For the function <m>f(x,y)=\frac{1}{3}y^3-y +x^2y</m>:
-			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Compute <m>f_{xx}, f_{yy},</m> and <m>f_{xy}</m>. Show all work.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					The critical points of <m>f(x,y)</m> are <m>(0,1),</m> <m>(0,-1),</m> <m>(-1,0)</m> and <m>(1,0)</m>. Determine, using the <m>D</m>-test, if each point corresponds to a relative maximum, relative minimum, or saddle point. Show all work.
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Use Lagrange multipliers to find the absolute maximum and the absolute minimum of <m>f(x, y) = x+4y</m> on the ellipse <m>x^2 + 2y^2 = 36.</m>
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Short answer questions. You do not need to justify your answer or show your work.
-			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Find the value of the infinite series <m>1 + 2 + \dfrac{2^2}{2!} + \dfrac{2^3}{3!} +
-											\dfrac{2^4}{4!}+\ldots</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find the domain of the function <m>f(x,y) = \ln(x - 3)\sqrt{y}.</m> Write your answer using set notation.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Let <m>y = x^3-x^2+1.</m> Find <m>dy</m> if <m>x=2</m> and <m>dx = 1/2.</m>
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
-			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					A company’s profit from producing <m>x</m> chairs and <m>y</m> tables per day is <m>P(x,y)</m>. Assume <m>P_y(46, 53) = 86.</m> Which of the following statements can we deduce from the provided information?
-				</p>
-				<ul>
-					<li>
-						<p>
-							Profit increases by about $86 per additional chair when producing 46 chairs and 53 tables per day.
-						</p>
+  <title>Math213-Midterm2</title>
+  <exercise>
+    <introduction>
+      <p>Determine the radius of convergence for the power series <m>\displaystyle\sum_{n=1}^{\infty} \dfrac{n^2 x^n}{2^n}</m>.</p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Modify a known series expansion to find the Taylor Series for <m>f(x) = \dfrac{x^2}{1+5x}</m> centered at 0. Please provide at least the first 5 terms of the series. You do not need to provide a formula for the general term.</p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>A company produces violins and cellos. If they price the violins at <m>x</m> dollars and the cellos at <m>y</m> dollars, they sell <m>200-2x+3y</m> violins a day and <m>300+x-4y</m> cellos a day.</p>
+    </introduction>
+    <task>
+      <statement>
+        <p>Find their revenue function <m>R(x,y)</m>.</p>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>If it costs <m>\$100</m> to produce a violin and <m>\$200</m> to produce a cello, with daily fixed costs at <m>\$500</m>, find their profit function <m>P(x,y)</m>.</p>
+      </statement>
+    </task>
+  </exercise>
+  <exercise>
+    <task>
+      <statement>
+        <p>Compute <m>\displaystyle\int_0^1\int_{x^2}^{\sqrt{x}}2xy\, dy\, dx</m></p>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Set up, but do not solve, a double integral that represents the volume under the surface <m>f(x,y) = x^2e^{xy}</m> and above the shaded region <m>R</m> bounded by <m>f(x)=x</m> and <m>g(x)=x^3</m> shown in the graph below.</p>
+      </statement>
+    </task>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Find the critical points of the function <m>f(x, y) = x^2 + 8xy + 4y^2 + 16x - 8y + 1.</m></p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>For the function <m>f(x,y)=\frac{1}{3}y^3-y +x^2y</m>:</p>
+    </introduction>
+    <task>
+      <statement>
+        <p>Compute <m>f_{xx}, f_{yy},</m> and <m>f_{xy}</m>. Show all work.</p>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>The critical points of <m>f(x,y)</m> are <m>(0,1),</m> <m>(0,-1),</m> <m>(-1,0)</m> and <m>(1,0)</m>. Determine, using the <m>D</m>-test, if each point corresponds to a relative maximum, relative minimum, or saddle point. Show all work.</p>
+      </statement>
+    </task>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Use Lagrange multipliers to find the absolute maximum and the absolute minimum of <m>f(x, y) = x+4y</m> on the ellipse <m>x^2 + 2y^2 = 36.</m></p>
+    </introduction>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Short answer questions. You do not need to justify your answer or show your work.</p>
+    </introduction>
+    <task>
+      <statement>
+        <p>Find the value of the infinite series <m>1 + 2 + \dfrac{2^2}{2!} + \dfrac{2^3}{3!} + \dfrac{2^4}{4!}+\ldots</m>.</p>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Find the domain of the function <m>f(x,y) = \ln(x - 3)\sqrt{y}.</m> Write your answer using set notation.</p>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Let <m>y = x^3-x^2+1.</m> Find <m>dy</m> if <m>x=2</m> and <m>dx = 1/2.</m></p>
+      </statement>
+    </task>
+  </exercise>
+  <exercise>
+    <introduction>
+      <p>Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term></p>
+    </introduction>
+    <task>
+      <statement>
+        <p>A company’s profit from producing <m>x</m> chairs and <m>y</m> tables per day is <m>P(x,y)</m>. Assume <m>P_y(46, 53) = 86.</m> Which of the following statements can we deduce from the provided information?</p>
+        <ul>
+          <li>
+            <p>Profit increases by about $86 per additional chair when producing 46 chairs and 53 tables per day.</p>
+          </li>
+          <li>
+            <p>Profit increases by about $86 per additional table when producing 46 chairs and 53 tables per day.</p>
+          </li>
+          <li>
+            <p>Profit is constant and equals $86, independent of how many chairs and/or tables are produced.</p>
+          </li>
+          <li>
+            <p>None of the above</p>
+          </li>
+          <li>
+            <p>All of the above</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Using the least squares method, the slope of the best-fit line for data points (1, 1), (2, 2), and (3, 4) is:</p>
+        <ul>
+          <li>
 					</li>
-					<li>
-						<p>
-							Profit increases by about $86 per additional table when producing 46 chairs and 53 tables per day.
-						</p>
+          <li>
 					</li>
-					<li>
-						<p>
-							Profit is constant and equals $86, independent of how many chairs and/or tables are produced.
-						</p>
+          <li>
 					</li>
-					<li>
-						<p>
-							None of the above
-						</p>
+          <li>
 					</li>
-					<li>
-						<p>
-							All of the above
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Using the least squares method, the slope of the best-fit line for data points (1, 1), (2, 2), and (3, 4) is:
-				</p>
-				<ul>
-					<li>
-					</li>
-					<li>
-					</li>
-					<li>
-					</li>
-					<li>
-					</li>
-				</ul>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Every function <m>f(x,y)</m> of two variables can be written as the sum of two functions of one variable, <m>g(x)+h(y).</m>
-				</p>
-				<ul>
-					<li>
-						<p>
-							True
-						</p>
-					</li>
-					<li>
-						<p>
-							False
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					At a critical point, <m>D=0</m> means that the point is <em>not</em> a relative maximum or minimum point.
-				</p>
-				<ul>
-					<li>
-						<p>
-							True
-						</p>
-					</li>
-					<li>
-						<p>
-							False
-						</p>
-					</li>
-				</ul>
-			</statement>
-		</task>
-	</exercise>
+        </ul>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>Every function <m>f(x,y)</m> of two variables can be written as the sum of two functions of one variable, <m>g(x)+h(y).</m></p>
+        <ul>
+          <li>
+            <p>True</p>
+          </li>
+          <li>
+            <p>False</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+    <task>
+      <statement>
+        <p>At a critical point, <m>D=0</m> means that the point is <em>not</em> a relative maximum or minimum point.</p>
+        <ul>
+          <li>
+            <p>True</p>
+          </li>
+          <li>
+            <p>False</p>
+          </li>
+        </ul>
+      </statement>
+    </task>
+  </exercise>
 </worksheet>

--- a/source/math213-exams/Math213-Midterm2.ptx
+++ b/source/math213-exams/Math213-Midterm2.ptx
@@ -114,13 +114,17 @@
         <p>Using the least squares method, the slope of the best-fit line for data points (1, 1), (2, 2), and (3, 4) is:</p>
         <ul>
           <li>
-					</li>
+            <p>0.5</p>
+          </li>
           <li>
-					</li>
+            <p>1</p>
+          </li>
           <li>
-					</li>
+            <p>1.5</p>
+          </li>
           <li>
-					</li>
+            <p>2</p>
+          </li>
         </ul>
       </statement>
     </task>

--- a/source/math213-exams/Math213-Midterm2.ptx
+++ b/source/math213-exams/Math213-Midterm2.ptx
@@ -22,7 +22,7 @@
     </task>
     <task>
       <statement>
-        <p>If it costs <m>\$100</m> to produce a violin and <m>\$200</m> to produce a cello, with daily fixed costs at <m>\$500</m>, find their profit function <m>P(x,y)</m>.</p>
+        <p>If it costs $100 to produce a violin and $200 to produce a cello, with daily fixed costs at $500, find their profit function <m>P(x,y)</m>.</p>
       </statement>
     </task>
   </exercise>

--- a/source/math213-exams/Math213-Midterm2.tex
+++ b/source/math213-exams/Math213-Midterm2.tex
@@ -13,8 +13,6 @@ not need to provide a formula for the general term.
 \question A company produces violins and cellos. If they price the violins at $x$ dollars and the
 cellos at $y$ dollars, they sell $200-2x+3y$ violins a day and $300+x-4y$ cellos a day.
 
-%\question A company's profit $P(x,y)$ from making $x$ violins and $y$ cellos per day is given
-%by $P(x,y) = 2x^2-3xy +3y^2 +150x+75y +200.$
 \begin{parts}
 \part[4] Find their revenue function $R(x,y)$.
 \vfill
@@ -51,15 +49,12 @@ thick,
 {x} node[pos=1, right]{$y=f(x)$};;
 \addplot [domain=-1.25:1.25, samples=100,<->, name path=g, very thick]
 {x^3} node[pos=1, above]{$y=g(x)$};
-%\node[font=\footnotesize] at (axis cs: 2,1.5) {$y=f(x)$};
-%\node[ font=\footnotesize] at (axis cs: 1.5,2.2) {$y=g(x)$};
 \addplot[gray!60, opacity=1] fill between[of=f and g, soft clip={domain=-1:0}];
 \node at (axis cs: -0.5,-0.3) {$R$};
 
 \end{axis}
 \end{tikzpicture}
 
-%Done! -KP
 \vfill
 
 \end{parts}


### PR DESCRIPTION
## Summary
- remove commented-out questions, notes, and development artifacts from the Math213 LaTeX exam sources
- regenerate the corresponding PreTeXt worksheets from the cleaned LaTeX using pandoc and add proper hint markup
- tidy generated worksheets by merging fragmented paragraphs created during conversion

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb64bdc81083289068fd45f510c689