### PR TITLE
Restore tab indentation for Math 213 instructions

### DIFF
--- a/source/math213-exams/Math213-FinalExam.ptx
+++ b/source/math213-exams/Math213-FinalExam.ptx
@@ -147,7 +147,7 @@
 	<exercise>
 		<introduction>
 			<p>
-				Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <term>No justification is needed.</term>
+				Clearly mark the correct answer for each of the following by completely filling in the appropriate bubble. <em>No justification is needed.</em>
 			</p>
 		</introduction>
 		<task>


### PR DESCRIPTION
## Summary
- restore the tab-based indentation on the Math 213 final exam instructions so the emphasis change no longer alters whitespace

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb6981f9488328b3a8c4d678bc3e68