### PR TITLE
Fix currency formatting for Math213 midterm conversion

### DIFF
--- a/pretext.lua
+++ b/pretext.lua
@@ -832,6 +832,10 @@ function Code(s, attr)
 end
 
 function InlineMath(s)
+  local currency_amount = s:match("^\\$([%d,%.%,%s]*%d)$")
+  if currency_amount then
+    return "$" .. escape(currency_amount)
+  end
   return "<m>" .. escape(s) .. "</m>"
 end
 

--- a/source/math213-exams/Math213-Midterm2.ptx
+++ b/source/math213-exams/Math213-Midterm2.ptx
@@ -22,7 +22,7 @@
     </task>
     <task>
       <statement>
-        <p>If it costs <m>\$100</m> to produce a violin and <m>\$200</m> to produce a cello, with daily fixed costs at <m>\$500</m>, find their profit function <m>P(x,y)</m>.</p>
+        <p>If it costs $100 to produce a violin and $200 to produce a cello, with daily fixed costs at $500, find their profit function <m>P(x,y)</m>.</p>
       </statement>
     </task>
   </exercise>


### PR DESCRIPTION
## Summary
- ensure the custom PreTeXt writer leaves simple currency amounts as plain text
- update the Math213 midterm prompt to display dollar amounts outside of math tags

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fb6c166dd48328bd5466bfb9ae86a0