### PR TITLE
Improve choice parsing and intro hints

### DIFF
--- a/pretext.lua
+++ b/pretext.lua
@@ -67,6 +67,63 @@ local function indent_line(text, level)
   return table.concat(lines, "\n")
 end
 
+local function clean_choice_chunk(chunk)
+  chunk = chunk or ""
+  chunk = chunk:gsub("\\chooseone%s*", "")
+  chunk = chunk:gsub("\\checkboxchar%s*%b{}", "")
+  chunk = chunk:gsub("^%s*%*+", "")
+  while true do
+    local before = chunk
+    chunk = chunk:gsub("^%s*%b[]", "", 1)
+    if chunk == before then break end
+  end
+  chunk = chunk:gsub("^%s+", "")
+  chunk = chunk:gsub("%s+$", "")
+  return chunk
+end
+
+local function convert_choice_body(body, marker)
+  local found = {}
+  body:gsub("()\\([A-Za-z]+)(%*?)", function(pos, name, star)
+    local lower = name:lower()
+    if lower:match("choice$") then
+      table.insert(found, {start = pos, name = name, star = star or ""})
+    end
+    return ""
+  end)
+  if #found == 0 then
+    return nil
+  end
+  local lines = {}
+  for index, info in ipairs(found) do
+    local macro_len = #info.name + #info.star + 1
+    local start_pos = info.start + macro_len
+    local next_start = found[index + 1] and found[index + 1].start or (#body + 1)
+    local segment = body:sub(start_pos, next_start - 1)
+    segment = clean_choice_chunk(segment)
+    if segment ~= "" then
+      table.insert(lines, "\\item <m>" .. marker .. "</m> " .. segment)
+    else
+      table.insert(lines, "\\item <m>" .. marker .. "</m>")
+    end
+  end
+  return table.concat(lines, "\n")
+end
+
+local function convert_choice_environment(text, env, marker)
+  local pattern = "\n%s*\\begin%s*{%s*" .. env .. "%s*}([%s%S]-)\\end%s*{%s*" .. env .. "%s*}"
+  local function replacer(body)
+    local converted = convert_choice_body(body, marker)
+    if not converted then
+      return "\n\\begin{itemize}\n" .. body .. "\n\\end{itemize}"
+    end
+    return "\n\\begin{itemize}\n" .. converted .. "\n\\end{itemize}"
+  end
+  local augmented = "\n" .. text
+  local replaced = augmented:gsub(pattern, replacer)
+  return replaced:sub(2)
+end
+
 local function render_paragraph(content, indent)
   content = trim(content)
   if content == "" then
@@ -382,15 +439,18 @@ local function extract_points(text)
 end
 
 local function strip_choice_marker(text)
-  local without = text:gsub("<m>\\Circle</m>%s*", "")
-  without = without:gsub("<m>\\Square</m>%s*", "")
+  local without = text:gsub("<m>PTXSINGLE</m>%s*", "")
+  without = without:gsub("<m>PTXMULTI</m>%s*", "")
+  without = without:gsub("&lt;m&gt;PTXSINGLE&lt;/m&gt;%s*", "")
+  without = without:gsub("&lt;m&gt;PTXMULTI&lt;/m&gt;%s*", "")
   without = without:gsub(" ", "")
   return trim(without)
 end
 
 local function is_choice_list(content)
   if not content then return false end
-  return content:find("<m>\\Circle</m>") or content:find("<m>\\Square</m>")
+  return content:find("<m>PTXSINGLE</m>") or content:find("<m>PTXMULTI</m>")
+    or content:find("&lt;m&gt;PTXSINGLE&lt;/m&gt;") or content:find("&lt;m&gt;PTXMULTI&lt;/m&gt;")
 end
 
 local function render_plain_list(tag, content, indent)
@@ -416,7 +476,7 @@ local function render_plain_list(tag, content, indent)
 end
 
 local function render_choices(list_content, indent)
-  local multiple = list_content:find("<m>\\Square</m>") and "yes" or "no"
+  local multiple = (list_content:find("<m>PTXMULTI</m>") or list_content:find("&lt;m&gt;PTXMULTI&lt;/m&gt;")) and "yes" or "no"
   local lines = {}
   table.insert(lines, indent_line('<choices multiple-correct="' .. multiple .. '">', indent))
   for _, entry in ipairs(parse_list_items(list_content)) do
@@ -452,6 +512,28 @@ local function normalize_hint(text)
   return trim(text)
 end
 
+local function split_text_and_hints(text)
+  local hints = {}
+  local remaining = text or ""
+  local function capture_hint(segment)
+    local normalized = normalize_hint(segment)
+    if normalized ~= "" then
+      table.insert(hints, normalized)
+    end
+    return ""
+  end
+  remaining = remaining:gsub("%s*(%(%s*[Hh]int:?[^%)]*%))", capture_hint)
+  remaining = trim(remaining)
+  if remaining ~= "" and remaining:match("^%(*%s*[Hh]int") then
+    local normalized = normalize_hint(remaining)
+    if normalized ~= "" then
+      table.insert(hints, normalized)
+    end
+    remaining = ""
+  end
+  return remaining, hints
+end
+
 local function extract_outermost_ol(source)
   local start = source:find("<ol>")
   if not start then
@@ -485,7 +567,28 @@ local function extract_outermost_ol(source)
 end
 
 local function convert_task(entry, indent, exercise_index, task_index)
-  local blocks = parse_blocks(entry)
+  local entry_kind = "item"
+  local entry_content = entry
+  if type(entry) == "table" then
+    entry_kind = entry.kind or "item"
+    entry_content = entry.content or ""
+  end
+  if entry_kind == "intro_hint" then
+    local lines = {}
+    table.insert(lines, indent_line("<task>", indent))
+    table.insert(lines, indent_line("<hint>", indent + 1))
+    local para = render_paragraph(entry_content, indent + 2)
+    if para then table.insert(lines, para) end
+    table.insert(lines, indent_line("</hint>", indent + 1))
+    table.insert(lines, indent_line("</task>", indent))
+    return table.concat(lines, "\n")
+  end
+  local blocks
+  if entry_kind == "choices" then
+    blocks = {{type = "list", tag = "ul", content = entry_content}}
+  else
+    blocks = parse_blocks(entry_content)
+  end
   local points
   local statement_parts = {}
   local hint_parts = {}
@@ -564,15 +667,29 @@ end
 local function convert_exercise(item, indent, exercise_index)
   local blocks = parse_blocks(item)
   local intro_blocks = {}
+  local intro_hint_blocks = {}
   local task_blocks = {}
   for _, block in ipairs(blocks) do
     if block.type == "list" then
-      for _, entry in ipairs(parse_list_items(block.content)) do
-        table.insert(task_blocks, entry)
+      if is_choice_list(block.content) then
+        table.insert(task_blocks, {kind = "choices", content = block.content})
+      else
+        for _, entry in ipairs(parse_list_items(block.content)) do
+          table.insert(task_blocks, {kind = "item", content = entry})
+        end
       end
     elseif block.type == "p" then
-      table.insert(intro_blocks, block.content)
+      local cleaned, hints = split_text_and_hints(block.content)
+      if cleaned ~= "" then
+        table.insert(intro_blocks, cleaned)
+      end
+      for _, hint_text in ipairs(hints) do
+        table.insert(intro_hint_blocks, hint_text)
+      end
     end
+  end
+  for _, hint_text in ipairs(intro_hint_blocks) do
+    table.insert(task_blocks, {kind = "intro_hint", content = hint_text})
   end
   local intro_points
   if intro_blocks[1] then
@@ -644,6 +761,9 @@ function Doc(body, metadata, variables)
     normalized = normalized:gsub([[\end%s*{%s*questions%s*}]], "\\end{enumerate}")
     normalized = normalized:gsub([[\begin%s*{%s*parts%s*}]], "\\begin{itemize}")
     normalized = normalized:gsub([[\end%s*{%s*parts%s*}]], "\\end{itemize}")
+    normalized = normalized:gsub([[\checkboxchar%s*%b{}]], "")
+    normalized = convert_choice_environment(normalized, "checkboxes", "PTXMULTI")
+    normalized = convert_choice_environment(normalized, "choices", "PTXSINGLE")
     normalized = normalized:gsub("\\question%[", "\\item[")
     normalized = normalized:gsub("\\question(%W)", function(follow)
       return "\\item" .. follow

--- a/source/math112-exams/Sp25 Final.ptx
+++ b/source/math112-exams/Sp25 Final.ptx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<worksheet xml:id="Sp25 Final" xmlns:xi="http://www.w3.org/2001/XInclude">
+<worksheet xml:id="Final" xmlns:xi="http://www.w3.org/2001/XInclude">
 	<title>Sp25 Final</title>
 	<introduction>
 		<p>

--- a/source/math112-exams/Sp25 Final.ptx
+++ b/source/math112-exams/Sp25 Final.ptx
@@ -1,0 +1,407 @@
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Sp25 Final" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Sp25 Final</title>
+	<introduction>
+		<p>
+				Multiple choice section. All points are for choosing the correct answer. No justification is needed.
+			</p>
+	</introduction>
+	<exercise>
+		<introduction>
+			<p>
+				Starting form the base function <m>|x|</m> (graph shown below).
+			</p>
+			<p>
+				Select the function graphed below.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Which of the following is a polynomial, <m>p(x)</m> with roots of <m>-3</m>, <m>\sqrt{2}</m>, and 1.
+			</p>
+		</introduction>
+		<task>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>p(x)=(x-3)(x+2)^2(x+1)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>p(x)=(x+3)(x-2)^2(x-1)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>p(x)=(x-3)(x+\sqrt{2})(x+1)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>p(x)=(x+3)(x-\sqrt{2})(x-1)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Consider the parabola <m>f(x)=(x+3)^2+k</m>. What is <m>k</m> if <m>f(x)</m> has only one zero?
+			</p>
+		</introduction>
+		<task>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>k=0</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>k&gt;0</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>k=-9</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>k=-3</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Consider the rational function <me>f(x)=\dfrac{x^3+5x+3}{2x^2+1}</me> What can we say about any asymptotes for this function?
+			</p>
+		</introduction>
+		<task>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>f(x)</m> has a horizontal asymptote at <m>y=0</m>.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>f(x)</m> has a horizontal asymptote at <m>y=\dfrac{1}{2}</m>.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								We cannot say anything about asymptotes of <m>f(x)</m>.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>f(x)</m> has a slant asymptote.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Let <m>f(x)=x^2-\sqrt{x+1}</m> and <m>g(x)=\dfrac{-3}{2x}</m>, what is <m>f(g(x))</m>?
+			</p>
+		</introduction>
+		<task>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>\dfrac{-3x}{2}+\dfrac{3\sqrt{x+1}}{2x}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\dfrac{9}{4x^2}-\sqrt{\frac{-3}{2x}+1}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\dfrac{-9}{4x^2}-\sqrt{\frac{-3}{2x}+1}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>\dfrac{-3}{2x^2-2\sqrt{x+1}}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				What is the domain of the following function: <me>f(x)=\dfrac{\sqrt{x+3}}{x-5}</me>
+			</p>
+			<p>
+				Free answer section. <term>Work must be shown to get credit for any answer.</term> Partial credit may be given even for incorrect final answers, so show your work.
+			</p>
+		</introduction>
+		<task>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>[-3,\infty)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>(-\infty,5)\bigcup(5,\infty)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>[-3,5)\bigcup(5,\infty)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>(-\infty,\infty)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Solve the following inequality and write your answers in interval notation. <me>|7x + 3| + 8 \geq 13\,</me>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Combine the following into a single fraction with no common factors on the top and bottom.
+			</p>
+			<p>
+				<me>\dfrac{3}{5x^2-10x}+\dfrac{2x}{x-2}</me>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<task>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								Write the function <m>f(x)=2x^{2}+4x+7</m> in vertex form, <m>a(x-h)^2+k</m>.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								What are the coordinates of the vertex?
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								Is the vertex a maximum or a minimum?
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Write the following as a single log. <me>f(x)=4\ln(x+2)-\frac{1}{2}\ln z+y\ln 3</me>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Consider the rational function <me>f(x)=\dfrac{x-5}{x^2+2x}</me>
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find the zero(s) of <m>f</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the vertical asymptote(s) of <m>f</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					For what intervals of <m>x</m> is <m>f(x)\le 0</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the inverse function for the function below: <me>f(x)=\dfrac{2x}{5-3x}</me>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Solve the following equation for <m>x:</m> <me>\begin{aligned}
+							        \log_{6}(x)+\log_6 (x-1) = 1
+							    
+							\end{aligned}</me>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For what value(s) of <m>x</m> does <me>\begin{aligned}
+							        \left(\ln(x)\right)^2 - 3\ln(x)=0\,?
+							    
+							\end{aligned}</me>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				A swimming pool is being emptied, and the amount of water (in liters) in the pool at time <m>t</m> (in minutes) is given by <me>P(t) = P_0 \cdot 5^{rt}</me> where <m>P_0</m> and <m>r</m> are some constants. If there is initially <m>1000</m> liters of water in the pool, and after <m>7</m> minutes there is <m>500</m> liters of water in the pool, find the values of <m>P_0</m> and <m>r</m>.
+			</p>
+		</introduction>
+		<task>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								What is <m>P_0</m>?
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								What is <m>r</m>? (Leave the value for <m>r</m> in terms of a logarithm.)
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								Knowing that the pool is being emptied, is <m>r</m> positive or negative?
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Consider the following polynomial <me>q(x)= 3x^3+16x^2+3x-10</me> Suppose we know <m>q(x)</m> has a root <m>x=-1</m>, write <m>q(x)</m> as a product of linear factors.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				For the following system of linear equations, determine whether or not the system has any solutions. If the system has a solution, state it as an ordered pair <m>(x,y)</m>; if the systems has infinitely many solutions, write your solutions as an ordered pair in terms of the variable <m>x</m> only. <me>\begin{cases}
+							4 x  +  3 y &amp; = 7 \\
+							- x  +  2 y &amp; = 5
+							\end{cases}</me>
+			</p>
+		</introduction>
+	</exercise>
+</worksheet>

--- a/source/math112-exams/Sp25 Midterm1.ptx
+++ b/source/math112-exams/Sp25 Midterm1.ptx
@@ -1,0 +1,321 @@
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Sp25 Midterm1" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Sp25 Midterm1</title>
+	<introduction>
+		<p>
+				Multiple choice section. All points are for choosing the correct answer(s). No justification is needed.
+			</p>
+	</introduction>
+	<exercise>
+		<introduction>
+			<p>
+				<term>Select ALL</term> of the following that are functions:
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the solution to the following inequality <me>|x-3|\ge-3</me>
+			</p>
+		</introduction>
+		<task>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>(-\infty,\infty)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>(-\infty,0]\cup[6,\infty)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								There is no <m>x</m> that solves the inequality.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>[0,6]</m>
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				<term>Select ALL</term> (real and complex) solutions to the equation: <me>x^3=-x</me>
+			</p>
+		</introduction>
+		<task>
+				<choices multiple-correct="yes">
+					<choice>
+						<statement>
+							<p>
+								<m>x=0</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=1</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=-1</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=i</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>x=-i</m>
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Select the correct graph of <m>f(x)=\left\{\begin{matrix}
+							    x^2 &amp;,&amp; x\ge 0\\
+							    -x &amp;,&amp; x&lt;0
+							\end{matrix}\right.</m>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				If <m>f(x)=5x^2-\dfrac{1}{3-x}</m>, What is <m>f(-2z)</m>?
+			</p>
+		</introduction>
+		<task>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>20z^2-\dfrac{1}{3+2z}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>-10z^3+\dfrac{2z}{3-z}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>-10z^3-\dfrac{2z}{3+2z}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>-20z^2+\dfrac{1}{3-2z}</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the domain of the function: <me>\dfrac{\sqrt{x+3}}{x-7}</me>
+			</p>
+			<p>
+				Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
+			</p>
+		</introduction>
+		<task>
+				<choices multiple-correct="no">
+					<choice>
+						<statement>
+							<p>
+								<m>(-\infty, -3)\bigcup(-3,7)\bigcup(7,\infty)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>(-\infty, 7)\bigcup(7,\infty)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>[-3,7)\bigcup(7,\infty)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>[-3,\infty)</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the Above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Given the graph of the function <m>y=F(x)</m> describing the temperature of lake Mendota over one year below:
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Given two points <m>A\left(\dfrac{1}{2},\dfrac{1}{2}\right)</m> and <m>B(0,-1)</m>. Find the equation of the line through <m>A</m> and <m>B</m>, write it in the point-slope form.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Given the line <m>y=\dfrac{2}{3}x-4</m>:
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Find the equation of the line through <m>(-3,1)</m> parallel to the line.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Find the equation of the line through the point <m>(-3,1)</m> perpendicular to the line.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Write the following as a single fraction. (In your final answer, make sure that the numerator and the denominator do not contain a common factor other than 1.)
+			</p>
+			<p>
+				<m>\displaystyle{\frac{x+2}{x^2+5x+4} + \frac{x+1}{2x+8}}</m>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Solve each of the following inequalities. For each part, express your answer in interval notation.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					<m>8 &lt; 9+4x \leq 11</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					<m>3x^2 \geq 13x-4</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Solve the given equation: <me>(x+2)(x+3)=12x-6</me>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Solve the given equation: <me>2x^2 -6x+1=0</me>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the possible value(s) for <m>x</m> if <me>2|x-5|+4 = 7.</me>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Find the values of <m>x</m> that solve the following equation: <me>(3-2x)^2-(3-2x)-2=0</me>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				The function graphed below represents the <term>Percentage of Children Under 5 with Acute Malnutrition (Wasting)</term> in a small occupied territory.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Solve the given equation: <me>\sqrt{x+7}-x+4=5</me>
+			</p>
+		</introduction>
+		<task>
+			<hint>
+				<p>
+					check your solutions.
+				</p>
+			</hint>
+		</task>
+	</exercise>
+</worksheet>

--- a/source/math112-exams/Sp25 Midterm1.ptx
+++ b/source/math112-exams/Sp25 Midterm1.ptx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<worksheet xml:id="Sp25 Midterm1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<worksheet xml:id="Midterm1" xmlns:xi="http://www.w3.org/2001/XInclude">
 	<title>Sp25 Midterm1</title>
 	<introduction>
 		<p>

--- a/source/math112-exams/Sp25 Midterm2.ptx
+++ b/source/math112-exams/Sp25 Midterm2.ptx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<worksheet xml:id="Sp25 Midterm2" xmlns:xi="http://www.w3.org/2001/XInclude">
+<worksheet xml:id="Midterm2" xmlns:xi="http://www.w3.org/2001/XInclude">
 	<title>Sp25 Midterm2</title>
 	<introduction>
 		<p>

--- a/source/math112-exams/Sp25 Midterm2.ptx
+++ b/source/math112-exams/Sp25 Midterm2.ptx
@@ -1,0 +1,344 @@
+<?xml version="1.0" encoding="utf-8"?>
+<worksheet xml:id="Sp25 Midterm2" xmlns:xi="http://www.w3.org/2001/XInclude">
+	<title>Sp25 Midterm2</title>
+	<introduction>
+		<p>
+				Multiple choice and fill in the blank section. All points are for choosing the correct answer. No justification is needed.
+			</p>
+	</introduction>
+	<exercise>
+		<introduction>
+			<p>
+				A parabola has a vertex of <m>(5,-2)</m>, and the vertex is a maximum. What is a possible equation for the parabola?
+			</p>
+		</introduction>
+		<task>
+				<choices multiple-correct="yes">
+					<choice>
+						<statement>
+							<p>
+								<m>y=(x+5)^2-2</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>y=-(x-5)^2+2</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>y=-(x-5)^2-2</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>y=-(x-2)^2+5</m>
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				The graph below has which properties?
+			</p>
+		</introduction>
+		<task>
+				<choices multiple-correct="yes">
+					<choice>
+						<statement>
+							<p>
+								The graph  a function and  have an inverse.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								The graph is  a function does  have an inverse.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								The graph is  a function, but  have an inverse.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								The graph  a function, but does  have an inverse.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Consider a polynomial <me>P(x) = ax^n</me> You know <m>n</m> is a positive integer, but do not know <m>a</m>. If as <m>x\to-\infty</m> <m>P(x)\to+\infty</m> and as <m>x\to+\infty</m> <m>P(x)\to-\infty</m>. What do you know about <m>a</m> and <m>n</m>?
+			</p>
+		</introduction>
+		<task>
+				<choices multiple-correct="yes">
+					<choice>
+						<statement>
+							<p>
+								<m>a</m> is positive and <m>n</m> is odd.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>a</m> is negative and <m>n</m> is odd.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>a</m> is negative and <m>n</m> is even.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								<m>a</m> is positive and <m>n</m> is even.
+							</p>
+						</statement>
+					</choice>
+					<choice>
+						<statement>
+							<p>
+								None of the above.
+							</p>
+						</statement>
+					</choice>
+				</choices>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Here is a graph of the parent function <m>f(x)= \sqrt{x}</m>.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Select the graph of <m>f(x)=x^2(x-2)^2</m>.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Every <m>3</m> years, an average family in the US generates <m>10</m> tons of trash. Your family created <m>95</m> tons of waste before you were born. Let <m>x</m> represent years after your birth.
+			</p>
+		</introduction>
+		<task workspace="-.7cm">
+			<statement>
+				<p>
+					Find a linear function <m>w=f(x)</m> that determines the total amount of waste created by an average family <m>w</m> as a function of time <m>x</m>.
+				</p>
+			</statement>
+		</task>
+		<task workspace="-.7cm">
+			<statement>
+				<p>
+					Find <m>f(21)</m> and explain what it tells you in this situation.
+				</p>
+			</statement>
+		</task>
+		<task workspace="-.7cm">
+			<statement>
+				<p>
+					Find <m>x=f^{-1}(w)</m> for value of <m>w</m>.
+				</p>
+			</statement>
+		</task>
+		<task workspace="-.7cm">
+			<statement>
+				<p>
+					Find <m>f^{-1}(205)</m> and explain what it tells you in this situation.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Perform the polynomial long division, then identify the quotient and the remainder. <me>\left(x^4+3 x^3+5x^2+2x+1\right) \div\left(x^2+1\right)</me>
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Suppose a ball is thrown directly upward, and its height (in feet) after <m>t</m> seconds is given by <me>y(t) = - 16 t^2 + 16t + a\,, \quad (\mathrm{ft})</me> with <m>a</m> to be determined.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					If at time <m>t=0</m>, the ball is thrown at height <m>10 \mathrm{ft}</m>, what is the value of <m>a</m>?
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Write the function <m>y(t)</m> in vertex form by completing the square.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					When does the ball reach its maximum height? What is the maximum height? Please include units for both answers.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<task>
+			<statement>
+				<p>
+					Find the polynomial <m>h(x)</m> of least possible degree with  that has a repeated root of <m>-3</m> with multiplicity 2 and a root of <m>\sqrt{5}</m> such that <m>h(0)=90</m>.
+				</p>
+				<p>
+					(You may leave your answer as a product of linear factors.)
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					What is the leading term of the polynomial and what is the degree of the polynomial?
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Compute the following.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					Let <m>f(x) = \dfrac{1}{2-x}</m> and <m>g(x) = \sqrt{x+12}.</m> Let <m>h(x) = \dfrac{f(x)}{g(x)}.</m> Compute <m>h(4).</m>
+				</p>
+			</statement>
+		</task>
+		<task workspace="1cm">
+			<statement>
+				<p>
+					Let <m>p(x) = \sqrt{-x + 6}</m> and <m>q(x) = \sqrt{x-1}</m>. Let <m>r(x) = p\cdot q(x)</m>. Find the domain of <m>r(x)</m>.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Let <m>a(x) = \dfrac{1}{5-x}</m> and <m>b(x) = x^2+1</m>. Compute <m>a \circ b(x)</m> and find its domain.
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Let <m>f(x)=\dfrac{3}{x+4}</m>. Find <m>f^{-1}(x)</m>, and find the domain of <m>f(x)</m>.
+			</p>
+		</introduction>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Let <m>g(x)=\sqrt{x+4}+1</m>. The graph is shown below.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					What is the domain and range of <m>g(x)</m>? (Write in interval notation.)
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					What is <m>g^{-1}(x)</m>? <m>g^{-1}(x) = \scalebox{1.2}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					What are the domain and range of <m>g^{-1}(x)</m>?
+				</p>
+			</statement>
+		</task>
+	</exercise>
+	<exercise>
+		<introduction>
+			<p>
+				Let <m>f(x)= 3 x^3 - 13 x^2 - 11 x + 5</m>.
+			</p>
+		</introduction>
+		<task>
+			<statement>
+				<p>
+					List all possible rational roots of <m>f(x)</m> according to the rational root theorem.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					We know that <m>f(x)</m> has a root at <m>x=5</m>. Use this fact to find all the roots of <m>f(x)</m>.
+				</p>
+			</statement>
+		</task>
+		<task>
+			<statement>
+				<p>
+					Write <m>f(x)</m> as a product of linear factors.
+				</p>
+				<p>
+					<m>\mbox{$f(x)=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{8cm} }}}</m>
+				</p>
+			</statement>
+		</task>
+	</exercise>
+</worksheet>


### PR DESCRIPTION
## Summary
- handle all choice-like macros and optional arguments when normalizing exam checkboxes so each option renders in its own <choice>
- extract inline Hint notes from exercise introductions into dedicated <hint> blocks so regenerated output keeps structured hints

## Testing
- for f in source/math112-exams/*.tex; do out="${f%.tex}.ptx"; pandoc "$f" -t pretext.lua -o "$out"; done

------
https://chatgpt.com/codex/tasks/task_e_6904311294e883289e3a2ec28e4e9783