### PR TITLE
Fix worksheet choice prompts to render separate options

### DIFF
--- a/source/math112-exams/Sp25 Final.ptx
+++ b/source/math112-exams/Sp25 Final.ptx
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<worksheet xml:id="Final" xmlns:xi="http://www.w3.org/2001/XInclude">
+<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="Final">
 	<title>Sp25 Final</title>
 	<introduction>
 		<p>
@@ -17,236 +17,236 @@
 		</introduction>
 	</exercise>
 	<exercise>
-		<introduction>
-			<p>
+		<task>
+			<statement>
+				<p>
 				Which of the following is a polynomial, <m>p(x)</m> with roots of <m>-3</m>, <m>\sqrt{2}</m>, and 1.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>p(x)=(x-3)(x+2)^2(x+1)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>p(x)=(x+3)(x-2)^2(x-1)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>p(x)=(x-3)(x+\sqrt{2})(x+1)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>p(x)=(x+3)(x-\sqrt{2})(x-1)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+			</statement>
+			<choices multiple-correct="no">
+				<choice>
+					<statement>
+						<p>
+							<m>p(x)=(x-3)(x+2)^2(x+1)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>p(x)=(x+3)(x-2)^2(x-1)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>p(x)=(x-3)(x+\sqrt{2})(x+1)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>p(x)=(x+3)(x-\sqrt{2})(x-1)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								None of the above.
 							</p>
-						</statement>
-					</choice>
-				</choices>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>
-		<introduction>
-			<p>
+		<task>
+			<statement>
+				<p>
 				Consider the parabola <m>f(x)=(x+3)^2+k</m>. What is <m>k</m> if <m>f(x)</m> has only one zero?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>k=0</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>k&gt;0</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>k=-9</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>k=-3</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+			</statement>
+			<choices multiple-correct="no">
+				<choice>
+					<statement>
+						<p>
+							<m>k=0</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>k&gt;0</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>k=-9</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>k=-3</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								None of the above.
 							</p>
-						</statement>
-					</choice>
-				</choices>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>
-		<introduction>
-			<p>
+		<task>
+			<statement>
+				<p>
 				Consider the rational function <me>f(x)=\dfrac{x^3+5x+3}{2x^2+1}</me> What can we say about any asymptotes for this function?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)</m> has a horizontal asymptote at <m>y=0</m>.
+			</statement>
+			<choices multiple-correct="no">
+				<choice>
+					<statement>
+						<p>
+							<m>f(x)</m> has a horizontal asymptote at <m>y=0</m>.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)</m> has a horizontal asymptote at <m>y=\dfrac{1}{2}</m>.
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>f(x)</m> has a horizontal asymptote at <m>y=\dfrac{1}{2}</m>.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								We cannot say anything about asymptotes of <m>f(x)</m>.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)</m> has a slant asymptote.
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>f(x)</m> has a slant asymptote.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								None of the above.
 							</p>
-						</statement>
-					</choice>
-				</choices>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>
-		<introduction>
-			<p>
+		<task>
+			<statement>
+				<p>
 				Let <m>f(x)=x^2-\sqrt{x+1}</m> and <m>g(x)=\dfrac{-3}{2x}</m>, what is <m>f(g(x))</m>?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>\dfrac{-3x}{2}+\dfrac{3\sqrt{x+1}}{2x}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>\dfrac{9}{4x^2}-\sqrt{\frac{-3}{2x}+1}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>\dfrac{-9}{4x^2}-\sqrt{\frac{-3}{2x}+1}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>\dfrac{-3}{2x^2-2\sqrt{x+1}}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+			</statement>
+			<choices multiple-correct="no">
+				<choice>
+					<statement>
+						<p>
+							<m>\dfrac{-3x}{2}+\dfrac{3\sqrt{x+1}}{2x}</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>\dfrac{9}{4x^2}-\sqrt{\frac{-3}{2x}+1}</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>\dfrac{-9}{4x^2}-\sqrt{\frac{-3}{2x}+1}</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>\dfrac{-3}{2x^2-2\sqrt{x+1}}</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								None of the above.
 							</p>
-						</statement>
-					</choice>
-				</choices>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>
-		<introduction>
-			<p>
+		<task>
+			<statement>
+				<p>
 				What is the domain of the following function: <me>f(x)=\dfrac{\sqrt{x+3}}{x-5}</me>
-			</p>
-			<p>
+				</p>
+				<p>
 				Free answer section. <term>Work must be shown to get credit for any answer.</term> Partial credit may be given even for incorrect final answers, so show your work.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>[-3,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty,5)\bigcup(5,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[-3,5)\bigcup(5,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+			</statement>
+			<choices multiple-correct="no">
+				<choice>
+					<statement>
+						<p>
+							<m>[-3,\infty)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>(-\infty,5)\bigcup(5,\infty)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>[-3,5)\bigcup(5,\infty)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>(-\infty,\infty)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								None of the above.
 							</p>
-						</statement>
-					</choice>
-				</choices>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>
@@ -268,29 +268,29 @@
 	</exercise>
 	<exercise>
 		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
+			<choices multiple-correct="no">
+				<choice>
+					<statement>
+						<p>
 								Write the function <m>f(x)=2x^{2}+4x+7</m> in vertex form, <m>a(x-h)^2+k</m>.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								What are the coordinates of the vertex?
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								Is the vertex a maximum or a minimum?
 							</p>
-						</statement>
-					</choice>
-				</choices>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>
@@ -338,7 +338,8 @@
 	<exercise>
 		<introduction>
 			<p>
-				Solve the following equation for <m>x:</m> <me>\begin{aligned}
+				Solve the following equation for <m>x:</m>
+				<me>\begin{aligned}
 							        \log_{6}(x)+\log_6 (x-1) = 1
 							    
 							\end{aligned}</me>
@@ -356,35 +357,35 @@
 		</introduction>
 	</exercise>
 	<exercise>
-		<introduction>
-			<p>
+		<task>
+			<statement>
+				<p>
 				A swimming pool is being emptied, and the amount of water (in liters) in the pool at time <m>t</m> (in minutes) is given by <me>P(t) = P_0 \cdot 5^{rt}</me> where <m>P_0</m> and <m>r</m> are some constants. If there is initially <m>1000</m> liters of water in the pool, and after <m>7</m> minutes there is <m>500</m> liters of water in the pool, find the values of <m>P_0</m> and <m>r</m>.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
+			</statement>
+			<choices multiple-correct="no">
+				<choice>
+					<statement>
+						<p>
 								What is <m>P_0</m>?
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								What is <m>r</m>? (Leave the value for <m>r</m> in terms of a logarithm.)
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								Knowing that the pool is being emptied, is <m>r</m> positive or negative?
 							</p>
-						</statement>
-					</choice>
-				</choices>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>

--- a/source/math112-exams/Sp25 Midterm1.ptx
+++ b/source/math112-exams/Sp25 Midterm1.ptx
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<worksheet xml:id="Midterm1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="Midterm1">
 	<title>Sp25 Midterm1</title>
 	<introduction>
 		<p>
@@ -14,88 +14,88 @@
 		</introduction>
 	</exercise>
 	<exercise>
-		<introduction>
-			<p>
-				Find the solution to the following inequality <me>|x-3|\ge-3</me>
-			</p>
-		</introduction>
 		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty,0]\cup[6,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+			<statement>
+				<p>
+				Find the solution to the following inequality <me>|x-3|\ge-3</me>
+				</p>
+			</statement>
+			<choices multiple-correct="no">
+				<choice>
+					<statement>
+						<p>
+							<m>(-\infty,\infty)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>(-\infty,0]\cup[6,\infty)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								There is no <m>x</m> that solves the inequality.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[0,6]</m>
-							</p>
-						</statement>
-					</choice>
-				</choices>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>[0,6]</m>
+						</p>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>
-		<introduction>
-			<p>
-				<term>Select ALL</term> (real and complex) solutions to the equation: <me>x^3=-x</me>
-			</p>
-		</introduction>
 		<task>
-				<choices multiple-correct="yes">
-					<choice>
-						<statement>
-							<p>
-								<m>x=0</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=-1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=i</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=-i</m>
-							</p>
-						</statement>
-					</choice>
-				</choices>
+			<statement>
+				<p>
+					<term>Select ALL</term> (real and complex) solutions to the equation: <me>x^3=-x</me>
+				</p>
+			</statement>
+			<choices multiple-correct="yes">
+				<choice>
+					<statement>
+						<p>
+							<m>x=0</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>x=1</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>x=-1</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>x=i</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>x=-i</m>
+						</p>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>
@@ -109,98 +109,98 @@
 		</introduction>
 	</exercise>
 	<exercise>
-		<introduction>
-			<p>
+		<task>
+			<statement>
+				<p>
 				If <m>f(x)=5x^2-\dfrac{1}{3-x}</m>, What is <m>f(-2z)</m>?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>20z^2-\dfrac{1}{3+2z}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-10z^3+\dfrac{2z}{3-z}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-10z^3-\dfrac{2z}{3+2z}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-20z^2+\dfrac{1}{3-2z}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+			</statement>
+			<choices multiple-correct="no">
+				<choice>
+					<statement>
+						<p>
+							<m>20z^2-\dfrac{1}{3+2z}</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>-10z^3+\dfrac{2z}{3-z}</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>-10z^3-\dfrac{2z}{3+2z}</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>-20z^2+\dfrac{1}{3-2z}</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								None of the above.
 							</p>
-						</statement>
-					</choice>
-				</choices>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>
-		<introduction>
-			<p>
+		<task>
+			<statement>
+				<p>
 				Find the domain of the function: <me>\dfrac{\sqrt{x+3}}{x-7}</me>
-			</p>
-			<p>
+				</p>
+				<p>
 				Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty, -3)\bigcup(-3,7)\bigcup(7,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty, 7)\bigcup(7,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[-3,7)\bigcup(7,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[-3,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+			</statement>
+			<choices multiple-correct="no">
+				<choice>
+					<statement>
+						<p>
+							<m>(-\infty, -3)\bigcup(-3,7)\bigcup(7,\infty)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>(-\infty, 7)\bigcup(7,\infty)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>[-3,7)\bigcup(7,\infty)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>[-3,\infty)</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								None of the Above.
 							</p>
-						</statement>
-					</choice>
-				</choices>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>

--- a/source/math112-exams/Sp25 Midterm2.ptx
+++ b/source/math112-exams/Sp25 Midterm2.ptx
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<worksheet xml:id="Midterm2" xmlns:xi="http://www.w3.org/2001/XInclude">
+<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="Midterm2">
 	<title>Sp25 Midterm2</title>
 	<introduction>
 		<p>
@@ -7,141 +7,143 @@
 			</p>
 	</introduction>
 	<exercise>
-		<introduction>
-			<p>
+		<task>
+			<statement>
+				<p>
 				A parabola has a vertex of <m>(5,-2)</m>, and the vertex is a maximum. What is a possible equation for the parabola?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="yes">
-					<choice>
-						<statement>
-							<p>
-								<m>y=(x+5)^2-2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=-(x-5)^2+2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=-(x-5)^2-2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=-(x-2)^2+5</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+			</statement>
+			<choices multiple-correct="yes">
+				<choice>
+					<statement>
+						<p>
+							<m>y=(x+5)^2-2</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>y=-(x-5)^2+2</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>y=-(x-5)^2-2</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>y=-(x-2)^2+5</m>
+						</p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								None of the above.
 							</p>
-						</statement>
-					</choice>
-				</choices>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>
-		<introduction>
-			<p>
+		<task>
+			<statement>
+				<p>
 				The graph below has which properties?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="yes">
-					<choice>
-						<statement>
-							<p>
+			</statement>
+			<choices multiple-correct="yes">
+				<choice>
+					<statement>
+						<p>
 								The graph  a function and  have an inverse.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								The graph is  a function does  have an inverse.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								The graph is  a function, but  have an inverse.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								The graph  a function, but does  have an inverse.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								None of the above.
 							</p>
-						</statement>
-					</choice>
-				</choices>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>
-		<introduction>
-			<p>
-				Consider a polynomial <me>P(x) = ax^n</me> You know <m>n</m> is a positive integer, but do not know <m>a</m>. If as <m>x\to-\infty</m> <m>P(x)\to+\infty</m> and as <m>x\to+\infty</m> <m>P(x)\to-\infty</m>. What do you know about <m>a</m> and <m>n</m>?
-			</p>
-		</introduction>
 		<task>
-				<choices multiple-correct="yes">
-					<choice>
-						<statement>
-							<p>
-								<m>a</m> is positive and <m>n</m> is odd.
+			<statement>
+				<p>
+				Consider a polynomial <me>P(x) = ax^n</me> You know <m>n</m> is a positive integer, but do not know <m>a</m>. If as <m>x\to-\infty</m>
+					<m>P(x)\to+\infty</m> and as <m>x\to+\infty</m>
+					<m>P(x)\to-\infty</m>. What do you know about <m>a</m> and <m>n</m>?
+			</p>
+			</statement>
+			<choices multiple-correct="yes">
+				<choice>
+					<statement>
+						<p>
+							<m>a</m> is positive and <m>n</m> is odd.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>a</m> is negative and <m>n</m> is odd.
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>a</m> is negative and <m>n</m> is odd.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>a</m> is negative and <m>n</m> is even.
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>a</m> is negative and <m>n</m> is even.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>a</m> is positive and <m>n</m> is even.
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
+							<m>a</m> is positive and <m>n</m> is even.
 							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
+					</statement>
+				</choice>
+				<choice>
+					<statement>
+						<p>
 								None of the above.
 							</p>
-						</statement>
-					</choice>
-				</choices>
+					</statement>
+				</choice>
+			</choices>
 		</task>
 	</exercise>
 	<exercise>


### PR DESCRIPTION
## Summary
- move multiple-choice exercise prompts from introductions into each task statement so PreTeXt can output one list item per choice
- remove redundant introductions once their content is embedded in the task statements for the Final and Midterm worksheets

## Testing
- `pretext build --deploys` *(fails: xelatex executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_690445e905f883289f7f4c765c808985