### PR TITLE
Remove task wrappers from standalone final exam questions

### DIFF
--- a/source/math112-exams/Sp25 Final.ptx
+++ b/source/math112-exams/Sp25 Final.ptx
@@ -16,14 +16,13 @@
 			</p>
 		</introduction>
 	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Which of the following is a polynomial, <m>p(x)</m> with roots of <m>-3</m>, <m>\sqrt{2}</m>, and 1.
-			</p>
-			</statement>
-			<choices multiple-correct="no">
+       <exercise>
+               <statement>
+                       <p>
+                               Which of the following is a polynomial, <m>p(x)</m> with roots of <m>-3</m>, <m>\sqrt{2}</m>, and 1.
+                       </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -59,17 +58,15 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Consider the parabola <m>f(x)=(x+3)^2+k</m>. What is <m>k</m> if <m>f(x)</m> has only one zero?
-			</p>
-			</statement>
-			<choices multiple-correct="no">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               Consider the parabola <m>f(x)=(x+3)^2+k</m>. What is <m>k</m> if <m>f(x)</m> has only one zero?
+                       </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -105,17 +102,15 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Consider the rational function <me>f(x)=\dfrac{x^3+5x+3}{2x^2+1}</me> What can we say about any asymptotes for this function?
-			</p>
-			</statement>
-			<choices multiple-correct="no">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               Consider the rational function <me>f(x)=\dfrac{x^3+5x+3}{2x^2+1}</me> What can we say about any asymptotes for this function?
+                       </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -151,17 +146,15 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Let <m>f(x)=x^2-\sqrt{x+1}</m> and <m>g(x)=\dfrac{-3}{2x}</m>, what is <m>f(g(x))</m>?
-			</p>
-			</statement>
-			<choices multiple-correct="no">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               Let <m>f(x)=x^2-\sqrt{x+1}</m> and <m>g(x)=\dfrac{-3}{2x}</m>, what is <m>f(g(x))</m>?
+                       </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -197,9 +190,8 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
+               </choices>
+       </exercise>
 	<exercise>
 		<task>
 			<statement>

--- a/source/math112-exams/Sp25 Midterm1.ptx
+++ b/source/math112-exams/Sp25 Midterm1.ptx
@@ -13,14 +13,13 @@
 			</p>
 		</introduction>
 	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Find the solution to the following inequality <me>|x-3|\ge-3</me>
-				</p>
-			</statement>
-			<choices multiple-correct="no">
+       <exercise>
+               <statement>
+                       <p>
+                               Find the solution to the following inequality <me>|x-3|\ge-3</me>
+                               </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -49,17 +48,15 @@
 						</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-					<term>Select ALL</term> (real and complex) solutions to the equation: <me>x^3=-x</me>
-				</p>
-			</statement>
-			<choices multiple-correct="yes">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               <term>Select ALL</term> (real and complex) solutions to the equation: <me>x^3=-x</me>
+                                </p>
+               </statement>
+               <choices multiple-correct="yes">
 				<choice>
 					<statement>
 						<p>
@@ -95,9 +92,8 @@
 						</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
+               </choices>
+       </exercise>
 	<exercise>
 		<introduction>
 			<p>
@@ -108,14 +104,13 @@
 			</p>
 		</introduction>
 	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				If <m>f(x)=5x^2-\dfrac{1}{3-x}</m>, What is <m>f(-2z)</m>?
-			</p>
-			</statement>
-			<choices multiple-correct="no">
+       <exercise>
+               <statement>
+                       <p>
+                               If <m>f(x)=5x^2-\dfrac{1}{3-x}</m>, What is <m>f(-2z)</m>?
+                        </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -151,20 +146,18 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Find the domain of the function: <me>\dfrac{\sqrt{x+3}}{x-7}</me>
-				</p>
-				<p>
-				Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
-			</p>
-			</statement>
-			<choices multiple-correct="no">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               Find the domain of the function: <me>\dfrac{\sqrt{x+3}}{x-7}</me>
+                               </p>
+                               <p>
+                               Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
+                       </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -200,9 +193,8 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
+               </choices>
+       </exercise>
 	<exercise>
 		<introduction>
 			<p>

--- a/source/math112-exams/Sp25 Midterm1.ptx
+++ b/source/math112-exams/Sp25 Midterm1.ptx
@@ -289,13 +289,34 @@
 			</p>
 		</introduction>
 	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				The function graphed below represents the <term>Percentage of Children Under 5 with Acute Malnutrition (Wasting)</term> in a small occupied territory.
-			</p>
-		</introduction>
-	</exercise>
+        <exercise>
+                <introduction>
+                        <p>
+                                The function graphed below represents the <term>Percentage of Children Under 5 with Acute Malnutrition (Wasting)</term> in a small occupied territory.
+                        </p>
+                </introduction>
+                <task>
+                        <statement>
+                                <p>
+                                        What was the average rate of change of wasting between 2000 and 2020?
+                                </p>
+                        </statement>
+                </task>
+                <task>
+                        <statement>
+                                <p>
+                                        What was the average rate of change of wasting between 2020 and 2024?
+                                </p>
+                        </statement>
+                </task>
+                <task>
+                        <statement>
+                                <p>
+                                        For what period of time (intervals) is the function <term>increasing</term>? Express your answer in interval notation.
+                                </p>
+                        </statement>
+                </task>
+        </exercise>
 	<exercise>
 		<introduction>
 			<p>

--- a/source/math112-exams/Sp25 Midterm2.ptx
+++ b/source/math112-exams/Sp25 Midterm2.ptx
@@ -6,14 +6,13 @@
 				Multiple choice and fill in the blank section. All points are for choosing the correct answer. No justification is needed.
 			</p>
 	</introduction>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				A parabola has a vertex of <m>(5,-2)</m>, and the vertex is a maximum. What is a possible equation for the parabola?
-			</p>
-			</statement>
-			<choices multiple-correct="yes">
+       <exercise>
+               <statement>
+                       <p>
+                               A parabola has a vertex of <m>(5,-2)</m>, and the vertex is a maximum. What is a possible equation for the parabola?
+                       </p>
+               </statement>
+               <choices multiple-correct="yes">
 				<choice>
 					<statement>
 						<p>
@@ -49,17 +48,15 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				The graph below has which properties?
-			</p>
-			</statement>
-			<choices multiple-correct="yes">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               The graph below has which properties?
+                       </p>
+               </statement>
+               <choices multiple-correct="yes">
 				<choice>
 					<statement>
 						<p>
@@ -95,19 +92,17 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Consider a polynomial <me>P(x) = ax^n</me> You know <m>n</m> is a positive integer, but do not know <m>a</m>. If as <m>x\to-\infty</m>
-					<m>P(x)\to+\infty</m> and as <m>x\to+\infty</m>
-					<m>P(x)\to-\infty</m>. What do you know about <m>a</m> and <m>n</m>?
-			</p>
-			</statement>
-			<choices multiple-correct="yes">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               Consider a polynomial <me>P(x) = ax^n</me> You know <m>n</m> is a positive integer, but do not know <m>a</m>. If as <m>x\to-\infty</m>
+                                       <m>P(x)\to+\infty</m> and as <m>x\to+\infty</m>
+                                       <m>P(x)\to-\infty</m>. What do you know about <m>a</m> and <m>n</m>?
+                       </p>
+               </statement>
+               <choices multiple-correct="yes">
 				<choice>
 					<statement>
 						<p>
@@ -143,9 +138,8 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
+               </choices>
+       </exercise>
 	<exercise>
 		<introduction>
 			<p>


### PR DESCRIPTION
## Summary
- stop wrapping questions 3–6 on the Spring 2025 final in <task> tags since they have no parts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69044cd9982483289c92b8ba85df9804