### PR TITLE
Convert exam TikZ graphics to PreTeXt latex-image assets

### DIFF
--- a/source/docinfo.ptx
+++ b/source/docinfo.ptx
@@ -2,4 +2,10 @@
 <docinfo xmlns:xi="http://www.w3.org/2001/XInclude">
   <macros>
   </macros>
+  <latex-image-preamble>
+    \usepackage{tikz}
+    \usetikzlibrary{calc,fit,shapes,3d}
+    \usepackage{pgfplots}
+    \pgfplotsset{compat=1.16}
+  </latex-image-preamble>
 </docinfo>

--- a/source/math112-exams/Sp25 Final.ptx
+++ b/source/math112-exams/Sp25 Final.ptx
@@ -6,16 +6,103 @@
 				Multiple choice section. All points are for choosing the correct answer. No justification is needed.
 			</p>
 	</introduction>
-	<exercise>
-		<introduction>
-			<p>
-				Starting form the base function <m>|x|</m> (graph shown below).
-			</p>
-			<p>
-				Select the function graphed below.
-			</p>
-		</introduction>
-	</exercise>
+        <exercise>
+                <introduction>
+                        <p>
+                                Starting form the base function <m>|x|</m> (graph shown below).
+                        </p>
+                        <figure xml:id="final-abs-base">
+                                <caption>Graph of the base function <m>y=|x|</m>.</caption>
+                                <image width="55%" alt="V-shaped graph with vertex at the origin opening upward.">
+                                        <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    grid=major,
+    width=.5\textwidth,
+    axis lines=middle,
+    xmin=-5,
+    xmax=5,
+    ymin=-5,
+    ymax=5,
+    xlabel={$x$},
+    ylabel={$y$},
+    xtick={-5,-4,-3,-2,-1,0,1,2,3,4,5},
+    ytick={-5,-4,-3,-2,-1,0,1,2,3,4,5}
+  ]
+    \addplot[smooth, thick, domain = -6:0,samples=2] { abs(x)};
+    \addplot[smooth, thick, domain = 0:6,samples=2] { abs(x)};
+  \end{axis}
+\end{tikzpicture}
+                                        ]]></latex-image>
+                                </image>
+                        </figure>
+                        <p>
+                                Select the function graphed below.
+                        </p>
+                        <figure xml:id="final-abs-transform">
+                                <caption>Transformed absolute value graph used in the question.</caption>
+                                <image width="55%" alt="V-shaped graph shifted right one unit, vertically scaled by one half, and shifted up two units.">
+                                        <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    grid=major,
+    width=.5\textwidth,
+    axis lines=middle,
+    xmin=-5,
+    xmax=5,
+    ymin=-5,
+    ymax=5,
+    xlabel={$x$},
+    ylabel={$y$},
+    xtick={-5,-4,-3,-2,-1,0,1,2,3,4,5},
+    ytick={-5,-4,-3,-2,-1,0,1,2,3,4,5}
+  ]
+    \addplot[smooth, thick, domain = -6:1,samples=2] { 0.5*abs(x-1)+2};
+    \addplot[smooth, thick, domain = 1:6,samples=2] { 0.5*abs(x-1)+2};
+  \end{axis}
+\end{tikzpicture}
+                                        ]]></latex-image>
+                                </image>
+                        </figure>
+                </introduction>
+                <choices multiple-correct="no">
+                        <choice>
+                                <statement>
+                                        <p>
+                                                <m>f(x)=2|x-1|+2</m>
+                                        </p>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <p>
+                                                <m>f(x)=2|x+1|+2</m>
+                                        </p>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <p>
+                                                <m>f(x)=\dfrac{1}{2}|x-1|+2</m>
+                                        </p>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <p>
+                                                <m>f(x)=\dfrac{1}{2}|x+1|+2</m>
+                                        </p>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <p>
+                                                None of the above.
+                                        </p>
+                                </statement>
+                        </choice>
+                </choices>
+        </exercise>
        <exercise>
                <statement>
                        <p>

--- a/source/math112-exams/Sp25 Midterm1.ptx
+++ b/source/math112-exams/Sp25 Midterm1.ptx
@@ -11,8 +11,100 @@
 			<p>
 				<term>Select ALL</term> of the following that are functions:
 			</p>
-		</introduction>
-	</exercise>
+                </introduction>
+                <choices multiple-correct="yes">
+                        <choice>
+                                <statement>
+                                        <image xml:id="mid1-relations-a" width="60%" alt="Mapping diagram with set A containing x, y, z and set B containing a, b, c, d where y maps to both b and c.">
+                                                <latex-image><![CDATA[
+\begin{tikzpicture}
+  \foreach[count=\i] \lseti/\lsetmi in {A/{x,y,z},B/{a,b,c,d}} {
+    \begin{scope}[local bounding box=\lseti, x=3cm, y=.5cm]
+      \foreach[count=\j] \lj in \lsetmi {
+        \node[minimum width=1em] (n-\j-\lseti) at (\i,-\j) {\lj};
+      }
+    \end{scope}
+    \node[ellipse, draw, fit=(\lseti),
+      label={[name=l-\lseti]above:$\lseti$}] {};
+  }
+  \draw[->] (n-1-A) -- (n-1-B);
+  \draw[->] (n-2-A) -- (n-2-B);
+  \draw[->] (n-3-A) -- (n-4-B);
+  \draw[->] (n-2-A) -- (n-3-B);
+\end{tikzpicture}
+                                                ]]></latex-image>
+                                        </image>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <image xml:id="mid1-relations-b" width="60%" alt="Mapping diagram with set A containing x, y, z, w and set B containing a, b, c where x and w both map to c.">
+                                                <latex-image><![CDATA[
+\begin{tikzpicture}
+  \foreach[count=\i] \lseti/\lsetmi in {A/{x,y,z,w},B/{a,b,c}} {
+    \begin{scope}[local bounding box=\lseti, x=3cm, y=.5cm]
+      \foreach[count=\j] \lj in \lsetmi {
+        \node[minimum width=1em] (n-\j-\lseti) at (\i,-\j) {\lj};
+      }
+    \end{scope}
+    \node[ellipse, draw, fit=(\lseti),
+      label={[name=l-\lseti]above:$\lseti$}] {};
+  }
+  \draw[->] (n-1-A) -- (n-2-B);
+  \draw[->] (n-2-A) -- (n-1-B);
+  \draw[->] (n-3-A) -- (n-3-B);
+  \draw[->] (n-4-A) -- (n-3-B);
+\end{tikzpicture}
+                                                ]]></latex-image>
+                                        </image>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <image xml:id="mid1-relations-c" width="60%" alt="Graph with a parabola opening upward for x greater than or equal to zero and a line with slope one for x less than zero.">
+                                                <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    grid=major,
+    axis x line = middle,
+    axis y line = middle,
+    yticklabel style = {font=\tiny,xshift=0.5ex},
+    xticklabel style = {font=\tiny,yshift=0.5ex},
+    width=5 cm,
+    height=5 cm,
+    xtick={-2,-1,0,1,2},
+    ytick={-2,-1,0,1,2,3,4},
+    xmin=-3.1,
+    xmax=3.1,
+    ymin=-2.1,
+    ymax=4.1,
+  ]
+    \addplot[smooth, thick, domain = 0:2,samples=35] { (x^2)};
+    \addplot[smooth, thick, domain = -3:0,samples=35] { -x};
+  \end{axis}
+\end{tikzpicture}
+                                                ]]></latex-image>
+                                        </image>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <image xml:id="mid1-relations-d" width="60%" alt="Hyperbola with vertical transverse axis drawn with asymptotic branches opening upward and downward.">
+                                                <latex-image><![CDATA[
+\begin{tikzpicture}[scale=.5]
+  \draw[->] (-3, 0) -- (3, 0) node[anchor=north west] {$x$};
+  \draw[->] (0, -3.5) -- (0, 3.5) node[anchor=south east] {$y$};
+  \draw[thick, smooth, domain=1:3.5, samples=20] plot ({sqrt((\x)^2/2 - .5)}, \x);
+  \draw[thick, smooth, domain=1:3.5, samples=20] plot ({-sqrt((\x)^2/2 - .5)}, \x);
+  \draw[thick, smooth, domain=-3.5:-1, samples=20] plot ({sqrt((\x)^2/2 - .5)}, \x);
+  \draw[thick, smooth, domain=-3.5:-1, samples=20] plot ({-sqrt((\x)^2/2 - .5)}, \x);
+\end{tikzpicture}
+                                                ]]></latex-image>
+                                        </image>
+                                </statement>
+                        </choice>
+                </choices>
+        </exercise>
        <exercise>
                <statement>
                        <p>
@@ -102,8 +194,122 @@
 							    -x &amp;,&amp; x&lt;0
 							\end{matrix}\right.</m>
 			</p>
-		</introduction>
-	</exercise>
+                </introduction>
+                <choices multiple-correct="no">
+                        <choice>
+                                <statement>
+                                        <image xml:id="mid1-piecewise-a" width="60%" alt="Graph with a parabola on the negative x-axis and a line with negative slope on the positive x-axis.">
+                                                <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    grid=major,
+    axis x line = middle,
+    axis y line = middle,
+    yticklabel style = {font=\tiny,xshift=0.5ex},
+    xticklabel style = {font=\tiny,yshift=0.5ex},
+    width=5 cm,
+    height=5 cm,
+    xtick={-2,-1,0,1,2},
+    ytick={-2,-1,0,1,2,3,4},
+    xmin=-3.1,
+    xmax=3.1,
+    ymin=-2.1,
+    ymax=4.1,
+  ]
+    \addplot[smooth, thick, domain = -2:0,samples=35] { (x^2)};
+    \addplot[smooth, thick, domain = 0:3,samples=35] { -x};
+  \end{axis}
+\end{tikzpicture}
+                                                ]]></latex-image>
+                                        </image>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <image xml:id="mid1-piecewise-b" width="60%" alt="Graph with the parabola drawn for positive x and a line with slope one drawn for negative x.">
+                                                <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    grid=major,
+    axis x line = middle,
+    axis y line = middle,
+    yticklabel style = {font=\tiny,xshift=0.5ex},
+    xticklabel style = {font=\tiny,yshift=0.5ex},
+    width=5 cm,
+    height=5 cm,
+    xtick={-2,-1,0,1,2},
+    ytick={-2,-1,0,1,2,3,4},
+    xmin=-3.1,
+    xmax=3.1,
+    ymin=-2.1,
+    ymax=4.1,
+  ]
+    \addplot[smooth, thick, domain = 0:2,samples=35] { (x^2)};
+    \addplot[smooth, thick, domain = -3:0,samples=35] { -x};
+  \end{axis}
+\end{tikzpicture}
+                                                ]]></latex-image>
+                                        </image>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <image xml:id="mid1-piecewise-c" width="60%" alt="Graph showing the entire parabola and the entire line plotted across all x-values.">
+                                                <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    grid=major,
+    axis x line = middle,
+    axis y line = middle,
+    yticklabel style = {font=\tiny,xshift=0.5ex},
+    xticklabel style = {font=\tiny,yshift=0.5ex},
+    width=5 cm,
+    height=5 cm,
+    xtick={-2,-1,0,1,2},
+    ytick={-2,-1,0,1,2,3,4},
+    xmin=-3.1,
+    xmax=3.1,
+    ymin=-2.1,
+    ymax=4.1,
+  ]
+    \addplot[smooth, thick, domain = -2.1:2.1,samples=35] { (x^2)};
+    \addplot[smooth, thick, domain = -3:3,samples=35] { -x};
+  \end{axis}
+\end{tikzpicture}
+                                                ]]></latex-image>
+                                        </image>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <image xml:id="mid1-piecewise-d" width="60%" alt="Graph plotting only the right half of the parabola and the line for positive x-values.">
+                                                <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    grid=major,
+    axis x line = middle,
+    axis y line = middle,
+    yticklabel style = {font=\tiny,xshift=0.5ex},
+    xticklabel style = {font=\tiny,yshift=0.5ex},
+    width=5 cm,
+    height=5 cm,
+    xtick={-2,-1,0,1,2},
+    ytick={-2,-1,0,1,2,3,4},
+    xmin=-3.1,
+    xmax=3.1,
+    ymin=-2.1,
+    ymax=4.1,
+  ]
+    \addplot[smooth, thick, domain = 0:2.1,samples=35] { (x^2)};
+    \addplot[smooth, thick, domain = 0:3,samples=35] { -x};
+  \end{axis}
+\end{tikzpicture}
+                                                ]]></latex-image>
+                                        </image>
+                                </statement>
+                        </choice>
+                </choices>
+        </exercise>
        <exercise>
                <statement>
                        <p>
@@ -200,6 +406,35 @@
                         <p>
                                 Given the graph of the function <m>y=F(x)</m> describing the temperature of lake Mendota over one year below:
                         </p>
+                        <figure xml:id="mid1-lake-graph">
+                                <caption>Seasonal temperature model for Lake Mendota.</caption>
+                                <image width="100%" alt="Smooth sinusoidal curve showing temperature in degrees Fahrenheit versus day of the year.">
+                                        <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    domain=0:365,
+    samples=200,
+    width=\textwidth,
+    height=8cm,
+    xlabel={$x$ (days)},
+    ylabel={$y$ ($^\circ$F)},
+    axis lines=middle,
+    grid=both,
+    major grid style={solid, gray},
+    minor grid style={solid, lightgray},
+    xmin=0, xmax=365,
+    ymin=0, ymax=75,
+    xtick={0,20,40,60,80,100,120,140,160,180,200,220,240,260,280,300,320,340,360},
+    ytick={0,10,20,30,40,50,60,70},
+    tick label style={font=\small},
+    xticklabel style={rotate=270, anchor=south, xshift=.3cm, yshift=-.25cm}
+  ]
+    \addplot[very thick] {25*sin(deg(pi/150*(x-115))) + 45};
+  \end{axis}
+\end{tikzpicture}
+                                        ]]></latex-image>
+                                </image>
+                        </figure>
                 </introduction>
                 <task>
                         <statement>
@@ -308,6 +543,39 @@
                         <p>
                                 The function graphed below represents the <term>Percentage of Children Under 5 with Acute Malnutrition (Wasting)</term> in a small occupied territory.
                         </p>
+                        <figure xml:id="mid1-malnutrition-graph">
+                                <caption>Reported percentage of children under five experiencing wasting.</caption>
+                                <image width="75%" alt="Blue curve rising from about two percent in 2000 to just over ten percent in 2024.">
+                                        <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    xlabel={Year},
+    ylabel={Wasting (\%)},
+    xtick={2000,2005,2010,2015,2017,2020,2022,2024},
+    ytick={0,1,2,3,4,5,6,7,8,9,10},
+    grid=both,
+    width=10cm,
+    height=7cm,
+    enlargelimits=true,
+    smooth,
+    domain=2000:2024
+  ]
+    \addplot[smooth, ultra thick, blue] coordinates {
+      (2000,2.0)
+      (2005,2.4)
+      (2010,2.9)
+      (2014.8,3.8)
+      (2017,3.0)
+      (2020,4.0)
+      (2022,4.7)
+      (2023.6,6.5)
+      (2024,10.1)
+    };
+  \end{axis}
+\end{tikzpicture}
+                                        ]]></latex-image>
+                                </image>
+                        </figure>
                 </introduction>
                 <task>
                         <statement>

--- a/source/math112-exams/Sp25 Midterm2.ptx
+++ b/source/math112-exams/Sp25 Midterm2.ptx
@@ -236,6 +236,7 @@
   \end{axis}
 \end{tikzpicture}
                                                         ]]></latex-image>
+                                                </image>
                                         </figure>
                                         <figure xml:id="mid2-root-graph-c">
                                                 <caption>Graph C</caption>
@@ -261,6 +262,7 @@
   \end{axis}
 \end{tikzpicture}
                                                         ]]></latex-image>
+                                                </image>
                                         </figure>
                                 </side>
                                 <side>
@@ -288,6 +290,7 @@
   \end{axis}
 \end{tikzpicture}
                                                         ]]></latex-image>
+                                                </image>
                                         </figure>
                                         <figure xml:id="mid2-root-graph-d">
                                                 <caption>Graph D</caption>
@@ -313,6 +316,7 @@
   \end{axis}
 \end{tikzpicture}
                                                         ]]></latex-image>
+                                                </image>
                                         </figure>
                                 </side>
                         </sidebyside>
@@ -347,6 +351,7 @@
   \end{axis}
 \end{tikzpicture}
                                                 ]]></latex-image>
+                                        </image>
                                 </statement>
                         </choice>
                         <choice>
@@ -371,6 +376,7 @@
   \end{axis}
 \end{tikzpicture}
                                                 ]]></latex-image>
+                                        </image>
                                 </statement>
                         </choice>
                         <choice>
@@ -395,6 +401,7 @@
   \end{axis}
 \end{tikzpicture}
                                                 ]]></latex-image>
+                                        </image>
                                 </statement>
                         </choice>
                         <choice>
@@ -419,6 +426,7 @@
   \end{axis}
 \end{tikzpicture}
                                                 ]]></latex-image>
+                                        </image>
                                 </statement>
                         </choice>
                         <choice>

--- a/source/math112-exams/Sp25 Midterm2.ptx
+++ b/source/math112-exams/Sp25 Midterm2.ptx
@@ -210,7 +210,7 @@
                         <p>
                                 <m>\boxed{\phantom{\dfrac{aaa}{b}}}</m> = <m>\displaystyle \frac{3}{2}\sqrt{-x+1}-1</m>
                         </p>
-                        <sidebyside widths="45%" valign="top">
+                        <sidebyside widths="45% 45%" valign="top">
                                 <side>
                                         <figure xml:id="mid2-root-graph-a">
                                                 <caption>Graph A</caption>

--- a/source/math112-exams/Sp25 Midterm2.ptx
+++ b/source/math112-exams/Sp25 Midterm2.ptx
@@ -55,6 +55,30 @@
                        <p>
                                The graph below has which properties?
                        </p>
+                        <image xml:id="mid2-function-inverse-graph" width="70%" alt="Cubic curve crossing the origin with open circles at negative and positive four on the x-axis.">
+                                <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    grid=both,
+    width=.6\textwidth,
+    axis lines=middle,
+    xlabel={$x$},
+    ylabel={$y$},
+    xmin=-6,
+    xmax=6,
+    ymin=-6,
+    ymax=6,
+    xtick={-6,-4,-2,0,2,4,6},
+    ytick={-6,-4,-2,0,2,4,6},
+    yticklabel style = {font=\footnotesize,xshift=0.5ex},
+    xticklabel style = {font=\footnotesize,yshift=0.5ex}
+  ]
+    \addplot[smooth, ultra thick, domain=-4:4, samples=200] {0.125*x^3-2*x};
+    \addplot[only marks,mark=*, mark options={scale=2, fill=none}, line width=0.3pt, mark size=1.5pt] coordinates{(-4,0) (4,0)};
+  \end{axis}
+\end{tikzpicture}
+                                ]]></latex-image>
+                        </image>
                </statement>
                <choices multiple-correct="yes">
 				<choice>
@@ -145,6 +169,32 @@
                         <p>
                                 Here is a graph of the parent function <m>f(x)= \sqrt{x}</m>.
                         </p>
+                        <figure xml:id="mid2-root-parent">
+                                <caption>Graph of the parent function <m>f(x)=\sqrt{x}</m>.</caption>
+                                <image width="70%" alt="Standard square-root curve starting at the origin and increasing slowly to the right.">
+                                        <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    domain=0:5,
+    samples=200,
+    xmin=-4, xmax=4,
+    ymin=-4, ymax=4,
+    axis equal,
+    axis lines=middle,
+    xlabel={$x$},
+    ylabel={$y$},
+    xtick={-4,-3,-2,-1,0,1,2,3,4},
+    ytick={-3,-2,-1,0,1,2,3},
+    grid=both,
+    minor grid style={dotted},
+    major grid style={semithick}
+  ]
+    \addplot[black, very thick, samples=250] {sqrt(x)};
+  \end{axis}
+\end{tikzpicture}
+                                        ]]></latex-image>
+                                </image>
+                        </figure>
                         <p>
                                 Match each function child function below to its graph. Write the letter of the corresponding graphs in the boxes next to the functions below.
                         </p>
@@ -160,15 +210,226 @@
                         <p>
                                 <m>\boxed{\phantom{\dfrac{aaa}{b}}}</m> = <m>\displaystyle \frac{3}{2}\sqrt{-x+1}-1</m>
                         </p>
+                        <sidebyside widths="45%" valign="top">
+                                <side>
+                                        <figure xml:id="mid2-root-graph-a">
+                                                <caption>Graph A</caption>
+                                                <image width="100%" alt="Square-root graph reflected across the y-axis, stretched vertically, and shifted right and down.">
+                                                        <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    domain=-5:1,
+    samples=200,
+    xmin=-4, xmax=4,
+    ymin=-4, ymax=4,
+    axis equal,
+    axis lines=middle,
+    xlabel={$x$},
+    ylabel={$y$},
+    xtick={-4,-3,-2,-1,0,1,2,3,4},
+    ytick={-3,-2,-1,0,1,2,3},
+    grid=both,
+    minor grid style={dotted},
+    major grid style={semithick}
+  ]
+    \addplot[black, very thick, samples=250] {1.5*sqrt(-x+1)-1};
+  \end{axis}
+\end{tikzpicture}
+                                                        ]]></latex-image>
+                                        </figure>
+                                        <figure xml:id="mid2-root-graph-c">
+                                                <caption>Graph C</caption>
+                                                <image width="100%" alt="Square-root graph reflected across both axes and shifted left and up.">
+                                                        <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    domain=-5:-1,
+    samples=200,
+    xmin=-4, xmax=4,
+    ymin=-4, ymax=4,
+    axis equal,
+    axis lines=middle,
+    xlabel={$x$},
+    ylabel={$y$},
+    xtick={-4,-3,-2,-1,0,1,2,3,4},
+    ytick={-3,-2,-1,0,1,2,3},
+    grid=both,
+    minor grid style={dotted},
+    major grid style={semithick}
+  ]
+    \addplot[black, very thick, samples=250] {-(2/3)*sqrt(-x-1)+1};
+  \end{axis}
+\end{tikzpicture}
+                                                        ]]></latex-image>
+                                        </figure>
+                                </side>
+                                <side>
+                                        <figure xml:id="mid2-root-graph-b">
+                                                <caption>Graph B</caption>
+                                                <image width="100%" alt="Square-root graph shifted left and up with a horizontal stretch.">
+                                                        <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    domain=-1:5,
+    samples=200,
+    xmin=-4, xmax=4,
+    ymin=-4, ymax=4,
+    axis equal,
+    axis lines=middle,
+    xlabel={$x$},
+    ylabel={$y$},
+    xtick={-4,-3,-2,-1,0,1,2,3,4},
+    ytick={-3,-2,-1,0,1,2,3},
+    grid=both,
+    minor grid style={dotted},
+    major grid style={semithick}
+  ]
+    \addplot[black, very thick, samples=250] {sqrt((3/2)*(x+1))+1};
+  \end{axis}
+\end{tikzpicture}
+                                                        ]]></latex-image>
+                                        </figure>
+                                        <figure xml:id="mid2-root-graph-d">
+                                                <caption>Graph D</caption>
+                                                <image width="100%" alt="Square-root graph reflected across the x-axis and shifted right and down.">
+                                                        <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    domain=1:5,
+    samples=200,
+    xmin=-4, xmax=4,
+    ymin=-4, ymax=4,
+    axis equal,
+    axis lines=middle,
+    xlabel={$x$},
+    ylabel={$y$},
+    xtick={-4,-3,-2,-1,0,1,2,3,4},
+    ytick={-3,-2,-1,0,1,2,3},
+    grid=both,
+    minor grid style={dotted},
+    major grid style={semithick}
+  ]
+    \addplot[black, very thick, samples=250] {-sqrt((2/3)*(x-1))-1};
+  \end{axis}
+\end{tikzpicture}
+                                                        ]]></latex-image>
+                                        </figure>
+                                </side>
+                        </sidebyside>
                 </introduction>
         </exercise>
 	<exercise>
-		<introduction>
-			<p>
-				Select the graph of <m>f(x)=x^2(x-2)^2</m>.
-			</p>
-		</introduction>
-	</exercise>
+                <introduction>
+                        <p>
+                                Select the graph of <m>f(x)=x^2(x-2)^2</m>.
+                        </p>
+                </introduction>
+                <choices multiple-correct="no">
+                        <choice>
+                                <statement>
+                                        <image xml:id="mid2-poly-graph-a" width="60%" alt="Quartic-like graph crossing the x-axis at zero and two with simple zeros.">
+                                                <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    grid=major,
+    axis x line = middle,
+    axis y line = middle,
+    xticklabel style = {font=\small,yshift=0.5ex},
+    width=5 cm,
+    height=5 cm,
+    xtick={-2,0,2},
+    ymin=-10,
+    ymax=10,
+    xmin=-4,
+    xmax=4
+  ]
+    \addplot[smooth, thick, domain = -5:5,samples=200] { x*(x-2)};
+  \end{axis}
+\end{tikzpicture}
+                                                ]]></latex-image>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <image xml:id="mid2-poly-graph-b" width="60%" alt="Graph with a triple root at two causing a flattened crossing there.">
+                                                <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    grid=major,
+    axis x line = middle,
+    axis y line = middle,
+    xticklabel style = {font=\small,yshift=0.5ex},
+    width=5 cm,
+    height=5 cm,
+    xtick={-2,0,2},
+    ymin=-5,
+    ymax=5,
+    xmin=-4,
+    xmax=4
+  ]
+    \addplot[smooth, thick, domain = -2:5,samples=200] { x*(x-2)^3};
+  \end{axis}
+\end{tikzpicture}
+                                                ]]></latex-image>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <image xml:id="mid2-poly-graph-c" width="60%" alt="Graph touching the x-axis at zero and two and remaining nonnegative.">
+                                                <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    grid=major,
+    axis x line = middle,
+    axis y line = middle,
+    xticklabel style = {font=\small,yshift=0.5ex},
+    width=5 cm,
+    height=5 cm,
+    xtick={-2,0,2},
+    ymin=-10,
+    ymax=10,
+    xmin=-4,
+    xmax=4
+  ]
+    \addplot[smooth, thick, domain = -5:5,samples=200] { x^2*(x-2)^2};
+  \end{axis}
+\end{tikzpicture}
+                                                ]]></latex-image>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <image xml:id="mid2-poly-graph-d" width="60%" alt="Graph crossing the x-axis at zero but only touching at two.">
+                                                <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    grid=major,
+    axis x line = middle,
+    axis y line = middle,
+    xticklabel style = {font=\small,yshift=0.5ex},
+    width=5 cm,
+    height=5 cm,
+    xtick={-2,0,2},
+    ymin=-10,
+    ymax=10,
+    xmin=-4,
+    xmax=4
+  ]
+    \addplot[smooth, thick, domain = -4:4,samples=200] { x*(x-2)^2};
+  \end{axis}
+\end{tikzpicture}
+                                                ]]></latex-image>
+                                </statement>
+                        </choice>
+                        <choice>
+                                <statement>
+                                        <p>
+                                                None of the above.
+                                        </p>
+                                </statement>
+                        </choice>
+                </choices>
+        </exercise>
 	<exercise>
 		<introduction>
 			<p>
@@ -305,12 +566,39 @@
 			</p>
 		</introduction>
 	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Let <m>g(x)=\sqrt{x+4}+1</m>. The graph is shown below.
-			</p>
-		</introduction>
+        <exercise>
+                <introduction>
+                        <p>
+                                Let <m>g(x)=\sqrt{x+4}+1</m>. The graph is shown below.
+                        </p>
+                        <figure xml:id="mid2-g-graph">
+                                <caption>Graph of <m>g(x)=\sqrt{x+4}+1</m>.</caption>
+                                <image width="70%" alt="Square-root graph starting at x equals negative four with an open circle and increasing to the right.">
+                                        <latex-image><![CDATA[
+\begin{tikzpicture}
+  \begin{axis}[
+    width=.7\textwidth,
+    height=.3\textwidth,
+    axis lines=middle,
+    grid=major,
+    xmin=-6,
+    xmax=6,
+    ymin=-1,
+    ymax=4,
+    xlabel={$x$},
+    ylabel={$y$},
+    xtick={-6,-4,-2,0,2,4,6},
+    ytick={-1,0,1,2,3,4}
+  ]
+    \addplot[smooth, thick, domain = -3:5,samples=200] { sqrt(x+4)+1};
+    \addplot[smooth, thick, domain = -4:-3,samples=50] { sqrt(x+4)+1};
+    \node at (axis cs:-4,1) [circle,fill=white,draw=black,inner sep=1.5pt] {};
+  \end{axis}
+\end{tikzpicture}
+                                        ]]></latex-image>
+                        </image>
+                        </figure>
+                </introduction>
                 <task>
                         <statement>
                                 <p>


### PR DESCRIPTION
## Summary
- add a LaTeX image preamble with TikZ and PGFPlots support for generated figures
- embed the TikZ diagrams from the Spring 2025 midterm and final exams as `<latex-image>` assets in their corresponding PreTeXt files
- provide descriptive captions/alt text and restore choice lists that accompany the graphical questions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69045bcfaa888328acad8e6d59ddeaa4