### PR TITLE
Restore Midterm and Final exam text lost in conversion

### DIFF
--- a/pretext.lua
+++ b/pretext.lua
@@ -333,6 +333,21 @@ end
 local function parse_blocks(block_str)
   local blocks = {}
   local rest = block_str or ""
+
+  local function strip_multicolumn_counter(content)
+    if not content then
+      return content
+    end
+    local stripped, count = content:gsub("^%s*%d+%s+(<)", "%1", 1)
+    if count > 0 then
+      return stripped
+    end
+    stripped, count = content:gsub("^%s*%d+%s+(\\)", "%1", 1)
+    if count > 0 then
+      return stripped
+    end
+    return content
+  end
   while rest do
     rest = rest:gsub("^%s+", "")
     if rest == "" then break end
@@ -368,7 +383,8 @@ local function parse_blocks(block_str)
       if direct_tag then
         local before, block, remainder = extract_outermost_list(rest, direct_tag)
         if before and trim(before) ~= "" then
-          table.insert(blocks, {type = "p", content = trim(before)})
+          local cleaned = strip_multicolumn_counter(trim(before))
+          table.insert(blocks, {type = "p", content = cleaned})
         end
         if block then
           table.insert(blocks, {type = "list", tag = direct_tag, content = strip_outer_list_markup(block, direct_tag)})
@@ -390,6 +406,7 @@ local function parse_blocks(block_str)
     if not handled then
       local para_content, remainder = rest:match("^<p>%s*(.-)%s*</p>(.*)$")
       if para_content then
+        para_content = strip_multicolumn_counter(para_content)
         table.insert(blocks, {type = "p", content = para_content})
         rest = remainder
       else

--- a/pretext.lua
+++ b/pretext.lua
@@ -337,6 +337,15 @@ local function parse_blocks(block_str)
     rest = rest:gsub("^%s+", "")
     if rest == "" then break end
 
+    -- Strip any leading HTML comments that might wrap other structures
+    while true do
+      local comment = rest:match("^<!%-%-.-%-%->")
+      if not comment then break end
+      rest = rest:sub(#comment + 1)
+      rest = rest:gsub("^%s+", "")
+    end
+    if rest == "" then break end
+
     local handled = false
 
     if rest:sub(1,3) == "<p>" then

--- a/pretext.lua
+++ b/pretext.lua
@@ -346,6 +346,10 @@ local function parse_blocks(block_str)
     if count > 0 then
       return stripped
     end
+    local trimmed = trim(content)
+    if trimmed:match("^%d+$") then
+      return ""
+    end
     return content
   end
   while rest do

--- a/source/math112-exams/Sp25 Final.ptx
+++ b/source/math112-exams/Sp25 Final.ptx
@@ -6,24 +6,65 @@
 				Multiple choice section. All points are for choosing the correct answer. No justification is needed.
 			</p>
 	</introduction>
-	<exercise>
-		<introduction>
-			<p>
-				Starting form the base function <m>|x|</m> (graph shown below).
-			</p>
-			<p>
-				Select the function graphed below.
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Which of the following is a polynomial, <m>p(x)</m> with roots of <m>-3</m>, <m>\sqrt{2}</m>, and 1.
-			</p>
-			</statement>
-			<choices multiple-correct="no">
+        <exercise>
+                <introduction>
+                        <p>
+                                Starting form the base function <m>|x|</m> (graph shown below).
+                        </p>
+                        <p>
+                                Select the function graphed below.
+                        </p>
+                        <p>
+                                2
+                        </p>
+                </introduction>
+                <task>
+                        <choices multiple-correct="yes">
+                                <choice>
+                                        <statement>
+                                                <p>
+                                                        A. <m>f(x)=2|x-1|+2</m>
+                                                </p>
+                                        </statement>
+                                </choice>
+                                <choice>
+                                        <statement>
+                                                <p>
+                                                        B. <m>f(x)=2|x+1|+2</m>
+                                                </p>
+                                        </statement>
+                                </choice>
+                                <choice>
+                                        <statement>
+                                                <p>
+                                                        C. <m>f(x)=\frac{1}{2}|x-1|+2</m>
+                                                </p>
+                                        </statement>
+                                </choice>
+                                <choice>
+                                        <statement>
+                                                <p>
+                                                        D. <m>f(x)=\frac{1}{2}|x+1|+2</m>
+                                                </p>
+                                        </statement>
+                                </choice>
+                                <choice>
+                                        <statement>
+                                                <p>
+                                                        E. None of the above.
+                                                </p>
+                                        </statement>
+                                </choice>
+                        </choices>
+                </task>
+        </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               Which of the following is a polynomial, <m>p(x)</m> with roots of <m>-3</m>, <m>\sqrt{2}</m>, and 1.
+                       </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -59,17 +100,15 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Consider the parabola <m>f(x)=(x+3)^2+k</m>. What is <m>k</m> if <m>f(x)</m> has only one zero?
-			</p>
-			</statement>
-			<choices multiple-correct="no">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               Consider the parabola <m>f(x)=(x+3)^2+k</m>. What is <m>k</m> if <m>f(x)</m> has only one zero?
+                       </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -105,17 +144,15 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Consider the rational function <me>f(x)=\dfrac{x^3+5x+3}{2x^2+1}</me> What can we say about any asymptotes for this function?
-			</p>
-			</statement>
-			<choices multiple-correct="no">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               Consider the rational function <me>f(x)=\dfrac{x^3+5x+3}{2x^2+1}</me> What can we say about any asymptotes for this function?
+                       </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -151,17 +188,15 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Let <m>f(x)=x^2-\sqrt{x+1}</m> and <m>g(x)=\dfrac{-3}{2x}</m>, what is <m>f(g(x))</m>?
-			</p>
-			</statement>
-			<choices multiple-correct="no">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               Let <m>f(x)=x^2-\sqrt{x+1}</m> and <m>g(x)=\dfrac{-3}{2x}</m>, what is <m>f(g(x))</m>?
+                       </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -197,9 +232,8 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
+               </choices>
+       </exercise>
 	<exercise>
 		<task>
 			<statement>
@@ -251,9 +285,12 @@
 	</exercise>
 	<exercise>
 		<introduction>
-			<p>
-				Solve the following inequality and write your answers in interval notation. <me>|7x + 3| + 8 \geq 13\,</me>
-			</p>
+                        <p>
+                                Solve the following inequality and write your answers in interval notation. <me>|7x + 3| + 8 \geq 13\,</me>
+                        </p>
+                        <p>
+                                <m>\mbox{Interval(s)}: \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+                        </p>
 		</introduction>
 	</exercise>
 	<exercise>
@@ -261,9 +298,12 @@
 			<p>
 				Combine the following into a single fraction with no common factors on the top and bottom.
 			</p>
-			<p>
-				<me>\dfrac{3}{5x^2-10x}+\dfrac{2x}{x-2}</me>
-			</p>
+                        <p>
+                                <me>\dfrac{3}{5x^2-10x}+\dfrac{2x}{x-2}</me>
+                        </p>
+                        <p>
+                                <m>\mbox{$f(x)=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{\dfrac{a}{b}}{b}} \hspace{5cm} }}}</m>
+                        </p>
 		</introduction>
 	</exercise>
     <exercise>
@@ -272,12 +312,18 @@
                             <p>
                             Write the function <m>f(x)=2x^{2}+4x+7</m> in vertex form, <m>a(x-h)^2+k</m>.
                             </p>
+                            <p>
+                            <m>\mbox{$f(x)=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+                            </p>
                     </statement>
             </task>
             <task>
                     <statement>
                             <p>
                             What are the coordinates of the vertex?
+                            </p>
+                            <p>
+                            <m>\mbox{Vertex: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{4cm} }}}</m>
                             </p>
                     </statement>
             </task>
@@ -287,13 +333,32 @@
                             Is the vertex a maximum or a minimum?
                             </p>
                     </statement>
+                    <choices multiple-correct="no">
+                            <choice>
+                                    <statement>
+                                            <p>
+                                            Maximum.
+                                            </p>
+                                    </statement>
+                            </choice>
+                            <choice>
+                                    <statement>
+                                            <p>
+                                            Minimum.
+                                            </p>
+                                    </statement>
+                            </choice>
+                    </choices>
             </task>
     </exercise>
 	<exercise>
 		<introduction>
-			<p>
-				Write the following as a single log. <me>f(x)=4\ln(x+2)-\frac{1}{2}\ln z+y\ln 3</me>
-			</p>
+                        <p>
+                                Write the following as a single log. <me>f(x)=4\ln(x+2)-\frac{1}{2}\ln z+y\ln 3</me>
+                        </p>
+                        <p>
+                                <m>\mbox{$f(x)=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{\dfrac{a}{b}}{b}} \hspace{5cm} }}}</m>
+                        </p>
 		</introduction>
 	</exercise>
 	<exercise>
@@ -302,33 +367,45 @@
 				Consider the rational function <me>f(x)=\dfrac{x-5}{x^2+2x}</me>
 			</p>
 		</introduction>
-		<task>
-			<statement>
-				<p>
-					Find the zero(s) of <m>f</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find the vertical asymptote(s) of <m>f</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					For what intervals of <m>x</m> is <m>f(x)\le 0</m>
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
+                <task>
+                        <statement>
+                                <p>
+                                        Find the zero(s) of <m>f</m>
+                                </p>
+                                <p>
+                                        <m>\mbox{$x=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+                                </p>
+                        </statement>
+                </task>
+                <task>
+                        <statement>
+                                <p>
+                                        Find the vertical asymptote(s) of <m>f</m>
+                                </p>
+                                <p>
+                                        <m>\mbox{$x=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+                                </p>
+                        </statement>
+                </task>
+                <task>
+                        <statement>
+                                <p>
+                                        For what intervals of <m>x</m> is <m>f(x)\le 0</m>
+                                </p>
+                                <p>
+                                        <m>\mbox{Interval(s)}: \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+                                </p>
+                        </statement>
+                </task>
+        </exercise>
+        <exercise>
 		<introduction>
-			<p>
-				Find the inverse function for the function below: <me>f(x)=\dfrac{2x}{5-3x}</me>
-			</p>
+                        <p>
+                                Find the inverse function for the function below: <me>f(x)=\dfrac{2x}{5-3x}</me>
+                        </p>
+                        <p>
+                                <m>\mbox{$f^{-1}(x)=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{\dfrac{a}{b}}{b}} \hspace{5cm} }}}</m>
+                        </p>
 		</introduction>
 	</exercise>
 	<exercise>
@@ -340,6 +417,9 @@
 							    
 							\end{aligned}</me>
 			</p>
+                        <p>
+                                <m>\mbox{$x$ = } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+                        </p>
 		</introduction>
 	</exercise>
 	<exercise>
@@ -350,6 +430,9 @@
 							    
 							\end{aligned}</me>
 			</p>
+                        <p>
+                                <m>\mbox{$x$ = } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+                        </p>
 		</introduction>
 	</exercise>
   <exercise>
@@ -358,43 +441,71 @@
                           A swimming pool is being emptied, and the amount of water (in liters) in the pool at time <m>t</m> (in minutes) is given by <me>P(t) = P_0 \cdot 5^{rt}</me> where <m>P_0</m> and <m>r</m> are some constants. If there is initially <m>1000</m> liters of water in the pool, and after <m>7</m> minutes there is <m>500</m> liters of water in the pool, find the values of <m>P_0</m> and <m>r</m>.
                   </p>
           </introduction>
-          <task>
-                  <statement>
-                          <p>
-                          What is <m>P_0</m>?
-                          </p>
-                  </statement>
-          </task>
-          <task>
-                  <statement>
-                          <p>
-                          What is <m>r</m>? (Leave the value for <m>r</m> in terms of a logarithm.)
-                          </p>
-                  </statement>
-          </task>
-          <task>
-                  <statement>
-                          <p>
-                          Knowing that the pool is being emptied, is <m>r</m> positive or negative?
-                          </p>
-                  </statement>
-          </task>
+                <task>
+                        <statement>
+                                <p>
+                                        What is <m>P_0</m>?
+                                </p>
+                                <p>
+                                        <m>\mbox{$P_0$ = } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+                                </p>
+                        </statement>
+                </task>
+                <task>
+                        <statement>
+                                <p>
+                                        What is <m>r</m>? (Leave the value for <m>r</m> in terms of a logarithm.)
+                                </p>
+                                <p>
+                                        <m>\mbox{$r$ = } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+                                </p>
+                        </statement>
+                </task>
+                <task>
+                        <statement>
+                                <p>
+                                        Knowing that the pool is being emptied, is <m>r</m> positive or negative?
+                                </p>
+                        </statement>
+                        <choices multiple-correct="no">
+                                <choice>
+                                        <statement>
+                                                <p>
+                                                <m>r</m> is positive
+                                                </p>
+                                        </statement>
+                                </choice>
+                                <choice>
+                                        <statement>
+                                                <p>
+                                                <m>r</m> is negative
+                                                </p>
+                                        </statement>
+                                </choice>
+                        </choices>
+                </task>
   </exercise>
 	<exercise>
 		<introduction>
-			<p>
-				Consider the following polynomial <me>q(x)= 3x^3+16x^2+3x-10</me> Suppose we know <m>q(x)</m> has a root <m>x=-1</m>, write <m>q(x)</m> as a product of linear factors.
-			</p>
+                        <p>
+                                Consider the following polynomial <me>q(x)= 3x^3+16x^2+3x-10</me> Suppose we know <m>q(x)</m> has a root <m>x=-1</m>, write <m>q(x)</m> as a product of linear factors.
+                        </p>
+                        <p>
+                                <m>\mbox{$q(x)$ = } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+                        </p>
 		</introduction>
 	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				For the following system of linear equations, determine whether or not the system has any solutions. If the system has a solution, state it as an ordered pair <m>(x,y)</m>; if the systems has infinitely many solutions, write your solutions as an ordered pair in terms of the variable <m>x</m> only. <me>\begin{cases}
-							4 x  +  3 y &amp; = 7 \\
-							- x  +  2 y &amp; = 5
-							\end{cases}</me>
-			</p>
-		</introduction>
+        <exercise>
+                <introduction>
+                        <p>
+                                For the following system of linear equations, determine whether or not the system has any solutions. If the system has a solution, state it as an ordered pair <m>(x,y)</m>; if the systems has infinitely many solutions, write your solutions as an ordered pair in terms of the variable <m>x</m> only. <me>\begin{cases}
+                                                        4 x  +  3 y &amp; = 7 \\
+                                                        - x  +  2 y &amp; = 5
+                                                        \end{cases}</me>
+                        </p>
+                        <p>
+                                <m>(x,y) = \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+                        </p>
+                </introduction>
 	</exercise>
 </worksheet>

--- a/source/math112-exams/Sp25 Final.ptx
+++ b/source/math112-exams/Sp25 Final.ptx
@@ -14,9 +14,6 @@
                         <p>
                                 Select the function graphed below.
                         </p>
-                        <p>
-                                2
-                        </p>
                 </introduction>
                 <task>
                         <choices multiple-correct="yes">

--- a/source/math112-exams/Sp25 Midterm1.ptx
+++ b/source/math112-exams/Sp25 Midterm1.ptx
@@ -11,9 +11,6 @@
                         <p>
                                 <term>Select ALL</term> of the following that are functions:
                         </p>
-                        <p>
-                                2
-                        </p>
                 </introduction>
         </exercise>
        <exercise>
@@ -104,9 +101,6 @@
                                                         x^2 &amp;,&amp; x\ge 0\\
                                                         -x &amp;,&amp; x&lt;0
                                                     \end{matrix}\right.</m>
-                        </p>
-                        <p>
-                                2
                         </p>
                 </introduction>
         </exercise>

--- a/source/math112-exams/Sp25 Midterm1.ptx
+++ b/source/math112-exams/Sp25 Midterm1.ptx
@@ -6,21 +6,23 @@
 				Multiple choice section. All points are for choosing the correct answer(s). No justification is needed.
 			</p>
 	</introduction>
-	<exercise>
-		<introduction>
-			<p>
-				<term>Select ALL</term> of the following that are functions:
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Find the solution to the following inequality <me>|x-3|\ge-3</me>
-				</p>
-			</statement>
-			<choices multiple-correct="no">
+        <exercise>
+                <introduction>
+                        <p>
+                                <term>Select ALL</term> of the following that are functions:
+                        </p>
+                        <p>
+                                2
+                        </p>
+                </introduction>
+        </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               Find the solution to the following inequality <me>|x-3|\ge-3</me>
+                               </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -49,17 +51,15 @@
 						</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-					<term>Select ALL</term> (real and complex) solutions to the equation: <me>x^3=-x</me>
-				</p>
-			</statement>
-			<choices multiple-correct="yes">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               <term>Select ALL</term> (real and complex) solutions to the equation: <me>x^3=-x</me>
+                                </p>
+               </statement>
+               <choices multiple-correct="yes">
 				<choice>
 					<statement>
 						<p>
@@ -95,27 +95,28 @@
 						</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Select the correct graph of <m>f(x)=\left\{\begin{matrix}
-							    x^2 &amp;,&amp; x\ge 0\\
-							    -x &amp;,&amp; x&lt;0
-							\end{matrix}\right.</m>
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				If <m>f(x)=5x^2-\dfrac{1}{3-x}</m>, What is <m>f(-2z)</m>?
-			</p>
-			</statement>
-			<choices multiple-correct="no">
+               </choices>
+       </exercise>
+        <exercise>
+                <introduction>
+                        <p>
+                                Select the correct graph of <m>f(x)=\left\{\begin{matrix}
+                                                        x^2 &amp;,&amp; x\ge 0\\
+                                                        -x &amp;,&amp; x&lt;0
+                                                    \end{matrix}\right.</m>
+                        </p>
+                        <p>
+                                2
+                        </p>
+                </introduction>
+        </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               If <m>f(x)=5x^2-\dfrac{1}{3-x}</m>, What is <m>f(-2z)</m>?
+                        </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -151,20 +152,18 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Find the domain of the function: <me>\dfrac{\sqrt{x+3}}{x-7}</me>
-				</p>
-				<p>
-				Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
-			</p>
-			</statement>
-			<choices multiple-correct="no">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               Find the domain of the function: <me>\dfrac{\sqrt{x+3}}{x-7}</me>
+                               </p>
+                               <p>
+                               Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
+                       </p>
+               </statement>
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -200,16 +199,29 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Given the graph of the function <m>y=F(x)</m> describing the temperature of lake Mendota over one year below:
-			</p>
-		</introduction>
-	</exercise>
+               </choices>
+       </exercise>
+        <exercise>
+                <introduction>
+                        <p>
+                                Given the graph of the function <m>y=F(x)</m> describing the temperature of lake Mendota over one year below:
+                        </p>
+                </introduction>
+                <task>
+                        <statement>
+                                <p>
+                                        Find the day(s) and temperature Lake Mendota reached a local maximum temperature.
+                                </p>
+                        </statement>
+                </task>
+                <task>
+                        <statement>
+                                <p>
+                                        Find the day(s) and temperature(s) Lake Mendota reached a local minimum temperature.
+                                </p>
+                        </statement>
+                </task>
+        </exercise>
 	<exercise>
 		<introduction>
 			<p>
@@ -297,13 +309,34 @@
 			</p>
 		</introduction>
 	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				The function graphed below represents the <term>Percentage of Children Under 5 with Acute Malnutrition (Wasting)</term> in a small occupied territory.
-			</p>
-		</introduction>
-	</exercise>
+        <exercise>
+                <introduction>
+                        <p>
+                                The function graphed below represents the <term>Percentage of Children Under 5 with Acute Malnutrition (Wasting)</term> in a small occupied territory.
+                        </p>
+                </introduction>
+                <task>
+                        <statement>
+                                <p>
+                                        What was the average rate of change of wasting between 2000 and 2020?
+                                </p>
+                        </statement>
+                </task>
+                <task>
+                        <statement>
+                                <p>
+                                        What was the average rate of change of wasting between 2020 and 2024?
+                                </p>
+                        </statement>
+                </task>
+                <task>
+                        <statement>
+                                <p>
+                                        For what period of time (intervals) is the function <term>increasing</term>? Express your answer in interval notation.
+                                </p>
+                        </statement>
+                </task>
+        </exercise>
 	<exercise>
 		<introduction>
 			<p>
@@ -312,9 +345,9 @@
 		</introduction>
 		<task>
 			<hint>
-				<p>
-					Check your solutions.
-				</p>
+                                <p>
+                                        check your solutions.
+                                </p>
 			</hint>
 		</task>
 	</exercise>

--- a/source/math112-exams/Sp25 Midterm2.ptx
+++ b/source/math112-exams/Sp25 Midterm2.ptx
@@ -152,7 +152,7 @@
                                 2
                         </p>
                         <p>
-                                2 <m>\boxed{\phantom{\dfrac{aaa}{b}}}</m> =<m>\displaystyle -\frac{2}{3}\sqrt{-x-1}+1</m>
+                                <m>\boxed{\phantom{\dfrac{aaa}{b}}}</m> =<m>\displaystyle -\frac{2}{3}\sqrt{-x-1}+1</m>
                         </p>
                         <p>
                                 <m>\boxed{\phantom{\dfrac{aaa}{b}}}</m> = <m>\displaystyle -\sqrt{\frac{2}{3}(x-1)}-1</m>
@@ -246,7 +246,7 @@
                                         When does the ball reach its maximum height? What is the maximum height? Please include units for both answers.
                                 </p>
                                 <p>
-                                        2 <m>\mbox{Max Height: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+                                        <m>\mbox{Max Height: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
                                 </p>
                                 <p>
                                         <m>\mbox{Time: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
@@ -271,7 +271,7 @@
                                         What is the leading term of the polynomial and what is the degree of the polynomial?
                                 </p>
                                 <p>
-                                        2 <m>\mbox{Leading term: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+                                        <m>\mbox{Leading term: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
                                 </p>
                                 <p>
                                         <m>\mbox{Degree: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
@@ -326,7 +326,7 @@
                                         What is the domain and range of <m>g(x)</m>? (Write in interval notation.)
                                 </p>
                                 <p>
-                                        2 <m>\mbox{Domain: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+                                        <m>\mbox{Domain: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
                                 </p>
                                 <p>
                                         <m>\mbox{Range: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
@@ -346,7 +346,7 @@
                                         What are the domain and range of <m>g^{-1}(x)</m>?
                                 </p>
                                 <p>
-                                        2 <m>\mbox{Domain: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+                                        <m>\mbox{Domain: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
                                 </p>
                                 <p>
                                         <m>\mbox{Range: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>

--- a/source/math112-exams/Sp25 Midterm2.ptx
+++ b/source/math112-exams/Sp25 Midterm2.ptx
@@ -6,14 +6,13 @@
 				Multiple choice and fill in the blank section. All points are for choosing the correct answer. No justification is needed.
 			</p>
 	</introduction>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				A parabola has a vertex of <m>(5,-2)</m>, and the vertex is a maximum. What is a possible equation for the parabola?
-			</p>
-			</statement>
-			<choices multiple-correct="yes">
+       <exercise>
+               <statement>
+                       <p>
+                               A parabola has a vertex of <m>(5,-2)</m>, and the vertex is a maximum. What is a possible equation for the parabola?
+                       </p>
+               </statement>
+               <choices multiple-correct="yes">
 				<choice>
 					<statement>
 						<p>
@@ -49,17 +48,15 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				The graph below has which properties?
-			</p>
-			</statement>
-			<choices multiple-correct="yes">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               The graph below has which properties?
+                       </p>
+               </statement>
+               <choices multiple-correct="yes">
 				<choice>
 					<statement>
 						<p>
@@ -95,19 +92,17 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
-			<statement>
-				<p>
-				Consider a polynomial <me>P(x) = ax^n</me> You know <m>n</m> is a positive integer, but do not know <m>a</m>. If as <m>x\to-\infty</m>
-					<m>P(x)\to+\infty</m> and as <m>x\to+\infty</m>
-					<m>P(x)\to-\infty</m>. What do you know about <m>a</m> and <m>n</m>?
-			</p>
-			</statement>
-			<choices multiple-correct="yes">
+               </choices>
+       </exercise>
+       <exercise>
+               <statement>
+                       <p>
+                               Consider a polynomial <me>P(x) = ax^n</me> You know <m>n</m> is a positive integer, but do not know <m>a</m>. If as <m>x\to-\infty</m>
+                                       <m>P(x)\to+\infty</m> and as <m>x\to+\infty</m>
+                                       <m>P(x)\to-\infty</m>. What do you know about <m>a</m> and <m>n</m>?
+                       </p>
+               </statement>
+               <choices multiple-correct="yes">
 				<choice>
 					<statement>
 						<p>
@@ -143,23 +138,46 @@
 							</p>
 					</statement>
 				</choice>
-			</choices>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Here is a graph of the parent function <m>f(x)= \sqrt{x}</m>.
-			</p>
-		</introduction>
-	</exercise>
-	<exercise>
-		<introduction>
-			<p>
-				Select the graph of <m>f(x)=x^2(x-2)^2</m>.
-			</p>
-		</introduction>
-	</exercise>
+               </choices>
+       </exercise>
+        <exercise>
+                <introduction>
+                        <p>
+                                Here is a graph of the parent function <m>f(x)= \sqrt{x}</m>.
+                        </p>
+                        <p>
+                                Match each function child function below to its graph. Write the letter of the corresponding graphs in the boxes next to the functions below.
+                        </p>
+                        <p>
+                                2
+                        </p>
+                        <p>
+                                2 <m>\boxed{\phantom{\dfrac{aaa}{b}}}</m> =<m>\displaystyle -\frac{2}{3}\sqrt{-x-1}+1</m>
+                        </p>
+                        <p>
+                                <m>\boxed{\phantom{\dfrac{aaa}{b}}}</m> = <m>\displaystyle -\sqrt{\frac{2}{3}(x-1)}-1</m>
+                        </p>
+                        <p>
+                                <m>\boxed{\phantom{\dfrac{aaa}{b}}}</m> = <m>\displaystyle \sqrt{\frac{3}{2}(x+1)}+1</m>
+                        </p>
+                        <p>
+                                <m>\boxed{\phantom{\dfrac{aaa}{b}}}</m> = <m>\displaystyle \frac{3}{2}\sqrt{-x+1}-1</m>
+                        </p>
+                </introduction>
+        </exercise>
+        <exercise>
+                <introduction>
+                        <p>
+                                Select the graph of <m>f(x)=x^2(x-2)^2</m>.
+                        </p>
+                        <p>
+                                2
+                        </p>
+                        <p>
+                                Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
+                        </p>
+                </introduction>
+        </exercise>
 	<exercise>
 		<introduction>
 			<p>
@@ -222,16 +240,22 @@
 				</p>
 			</statement>
 		</task>
-		<task>
-			<statement>
-				<p>
-					When does the ball reach its maximum height? What is the maximum height? Please include units for both answers.
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<task>
+                <task>
+                        <statement>
+                                <p>
+                                        When does the ball reach its maximum height? What is the maximum height? Please include units for both answers.
+                                </p>
+                                <p>
+                                        2 <m>\mbox{Max Height: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+                                </p>
+                                <p>
+                                        <m>\mbox{Time: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+                                </p>
+                        </statement>
+                </task>
+        </exercise>
+        <exercise>
+                <task>
 			<statement>
 				<p>
 					Find the polynomial <m>h(x)</m> of least possible degree with  that has a repeated root of <m>-3</m> with multiplicity 2 and a root of <m>\sqrt{5}</m> such that <m>h(0)=90</m>.
@@ -241,16 +265,22 @@
 				</p>
 			</statement>
 		</task>
-		<task>
-			<statement>
-				<p>
-					What is the leading term of the polynomial and what is the degree of the polynomial?
-				</p>
-			</statement>
-		</task>
-	</exercise>
-	<exercise>
-		<introduction>
+                <task>
+                        <statement>
+                                <p>
+                                        What is the leading term of the polynomial and what is the degree of the polynomial?
+                                </p>
+                                <p>
+                                        2 <m>\mbox{Leading term: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+                                </p>
+                                <p>
+                                        <m>\mbox{Degree: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+                                </p>
+                        </statement>
+                </task>
+        </exercise>
+        <exercise>
+                <introduction>
 			<p>
 				Compute the following.
 			</p>
@@ -290,28 +320,40 @@
 				Let <m>g(x)=\sqrt{x+4}+1</m>. The graph is shown below.
 			</p>
 		</introduction>
-		<task>
-			<statement>
-				<p>
-					What is the domain and range of <m>g(x)</m>? (Write in interval notation.)
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
+                <task>
+                        <statement>
+                                <p>
+                                        What is the domain and range of <m>g(x)</m>? (Write in interval notation.)
+                                </p>
+                                <p>
+                                        2 <m>\mbox{Domain: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+                                </p>
+                                <p>
+                                        <m>\mbox{Range: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+                                </p>
+                        </statement>
+                </task>
+                <task>
+                        <statement>
 				<p>
 					What is <m>g^{-1}(x)</m>? <m>g^{-1}(x) = \scalebox{1.2}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
 				</p>
 			</statement>
 		</task>
-		<task>
-			<statement>
-				<p>
-					What are the domain and range of <m>g^{-1}(x)</m>?
-				</p>
-			</statement>
-		</task>
-	</exercise>
+                <task>
+                        <statement>
+                                <p>
+                                        What are the domain and range of <m>g^{-1}(x)</m>?
+                                </p>
+                                <p>
+                                        2 <m>\mbox{Domain: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+                                </p>
+                                <p>
+                                        <m>\mbox{Range: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+                                </p>
+                        </statement>
+                </task>
+        </exercise>
 	<exercise>
 		<introduction>
 			<p>

--- a/source/math112-exams/Sp25 Midterm2.ptx
+++ b/source/math112-exams/Sp25 Midterm2.ptx
@@ -148,9 +148,7 @@
                         <p>
                                 Match each function child function below to its graph. Write the letter of the corresponding graphs in the boxes next to the functions below.
                         </p>
-                        <p>
-                                2
-                        </p>
+                        
                         <p>
                                 <m>\boxed{\phantom{\dfrac{aaa}{b}}}</m> =<m>\displaystyle -\frac{2}{3}\sqrt{-x-1}+1</m>
                         </p>
@@ -170,9 +168,7 @@
                         <p>
                                 Select the graph of <m>f(x)=x^2(x-2)^2</m>.
                         </p>
-                        <p>
-                                2
-                        </p>
+                        
                         <p>
                                 Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
                         </p>


### PR DESCRIPTION
## Summary
- add the missing multiple-choice options, workspace prompts, and instructions that the updated converter produces for the Spring 2025 Final PreTeXt source
- mirror the new converter output for Midterm 2 by restoring the free-response guidance and boxed answer placeholders that were previously dropped
- align Midterm 1 introductions and hints with the regenerated files so point markers and helper text match the LaTeX originals

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69044cd9982483289c92b8ba85df9804