### PR TITLE
Fix multiple choice detection for single-answer questions

### DIFF
--- a/pretext.lua
+++ b/pretext.lua
@@ -504,7 +504,9 @@ local function render_plain_list(tag, content, indent)
 end
 
 local function render_choices(list_content, indent)
-  local multiple = (list_content:find("<m>PTXMULTI</m>") or list_content:find("&lt;m&gt;PTXMULTI&lt;/m&gt;")) and "yes" or "no"
+  local has_multi = list_content:find("<m>PTXMULTI</m>") or list_content:find("&lt;m&gt;PTXMULTI&lt;/m&gt;")
+  local has_single = list_content:find("<m>PTXSINGLE</m>") or list_content:find("&lt;m&gt;PTXSINGLE&lt;/m&gt;")
+  local multiple = (has_multi and not has_single) and "yes" or "no"
   local lines = {}
   table.insert(lines, indent_line('<choices multiple-correct="' .. multiple .. '">', indent))
   for _, entry in ipairs(parse_list_items(list_content)) do

--- a/source/math112-exams/Sp25 Final.ptx
+++ b/source/math112-exams/Sp25 Final.ptx
@@ -16,7 +16,7 @@
                         </p>
                 </introduction>
                 <task>
-                        <choices multiple-correct="yes">
+<choices multiple-correct="no">
                                 <choice>
                                         <statement>
                                                 <p>

--- a/source/math112-exams/Sp25 Midterm2.ptx
+++ b/source/math112-exams/Sp25 Midterm2.ptx
@@ -12,7 +12,7 @@
                                A parabola has a vertex of <m>(5,-2)</m>, and the vertex is a maximum. What is a possible equation for the parabola?
                        </p>
                </statement>
-               <choices multiple-correct="yes">
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -56,7 +56,7 @@
                                The graph below has which properties?
                        </p>
                </statement>
-               <choices multiple-correct="yes">
+               <choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>
@@ -102,7 +102,7 @@
                                        <m>P(x)\to-\infty</m>. What do you know about <m>a</m> and <m>n</m>?
                        </p>
                </statement>
-               <choices multiple-correct="yes">
+<choices multiple-correct="no">
 				<choice>
 					<statement>
 						<p>


### PR DESCRIPTION
## Summary
- ensure the PreTeXt writer only marks exercises as multiple-correct when multi-select markers are present without single-select markers
- update Math 112 Spring 2025 assessments so single-answer questions use multiple-correct="no"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690466c07fec83288252c067e8a424c2