### PR TITLE
Flatten exercise markup for PreTeXT

### DIFF
--- a/pretext.lua
+++ b/pretext.lua
@@ -800,7 +800,11 @@ local function convert_task(entry, indent, exercise_index, task_index, context_t
     if para then table.insert(lines, para) end
     table.insert(lines, indent_line("</hint>", indent + 1))
     table.insert(lines, indent_line("</task>", indent))
-    return table.concat(lines, "\n")
+    local metadata = {
+      kind = entry_kind,
+      hints = {entry_content}
+    }
+    return table.concat(lines, "\n"), context_text, metadata
   end
   local blocks
   if entry_kind == "choices" then
@@ -813,6 +817,7 @@ local function convert_task(entry, indent, exercise_index, task_index, context_t
   local hint_parts = {}
   local choices_markup = nil
   local choice_list_content = nil
+  local choice_forced_mode = nil
   local workspace
   for index, block in ipairs(blocks) do
     if block.type == "p" then
@@ -852,8 +857,8 @@ local function convert_task(entry, indent, exercise_index, task_index, context_t
   end
 
   if choice_list_content then
-    local forced_mode = determine_forced_mode(choice_list_content, combined_context)
-    choices_markup = render_choices(choice_list_content, indent + 2, forced_mode)
+    choice_forced_mode = determine_forced_mode(choice_list_content, combined_context)
+    choices_markup = render_choices(choice_list_content, indent + 2, choice_forced_mode)
   end
 
   if (not workspace or workspace == "") and exercise_index and task_index then
@@ -898,7 +903,16 @@ local function convert_task(entry, indent, exercise_index, task_index, context_t
   if next_context == "" then
     next_context = context_text
   end
-  return table.concat(lines, "\n"), next_context
+  local metadata = {
+    kind = entry_kind,
+    points = points,
+    workspace = workspace,
+    statement_parts = statement_parts,
+    hints = hint_parts,
+    choice_list_content = choice_list_content,
+    choice_forced_mode = choice_forced_mode
+  }
+  return table.concat(lines, "\n"), next_context, metadata
 end
 
 local function convert_exercise(item, indent, exercise_index)
@@ -939,19 +953,98 @@ local function convert_exercise(item, indent, exercise_index)
   end
   local lines = {}
   table.insert(lines, indent_line("<exercise" .. attr .. ">", indent))
-  if #intro_blocks > 0 then
-    table.insert(lines, indent_line("<introduction>", indent + 1))
-    for _, content in ipairs(intro_blocks) do
-      local para = render_paragraph(content, indent + 2)
-      if para then table.insert(lines, para) end
-    end
-    table.insert(lines, indent_line("</introduction>", indent + 1))
-  end
   local context_text = intro_context
+  local task_results = {}
   for idx, entry in ipairs(task_blocks) do
-    local task_markup, updated_context = convert_task(entry, indent + 1, exercise_index, idx, context_text)
-    table.insert(lines, task_markup)
+    local task_markup, updated_context, metadata = convert_task(entry, indent + 1, exercise_index, idx, context_text)
+    table.insert(task_results, {markup = task_markup, metadata = metadata})
     context_text = updated_context or context_text
+  end
+  local flattened_parts = {}
+  for _, content in ipairs(intro_blocks) do
+    table.insert(flattened_parts, {type = "p", content = content})
+  end
+  local flattened_hints = {}
+  local flattened_choices = {}
+  local task_points
+  local can_flatten = true
+  for _, result in ipairs(task_results) do
+    local metadata = result.metadata
+    if not metadata then
+      can_flatten = false
+      break
+    end
+    if metadata.kind == "intro_hint" then
+      for _, hint_text in ipairs(metadata.hints or {}) do
+        table.insert(flattened_hints, hint_text)
+      end
+    else
+      if metadata.statement_parts then
+        for _, part in ipairs(metadata.statement_parts) do
+          if part.type == "p" then
+            table.insert(flattened_parts, {type = "p", content = part.content})
+          elseif part.type == "list" then
+            table.insert(flattened_parts, {type = "list", tag = part.tag, content = part.content})
+          end
+        end
+      end
+      if metadata.hints then
+        for _, hint_text in ipairs(metadata.hints) do
+          table.insert(flattened_hints, hint_text)
+        end
+      end
+      if metadata.choice_list_content then
+        table.insert(flattened_choices, {
+          content = metadata.choice_list_content,
+          forced_mode = metadata.choice_forced_mode
+        })
+      end
+      if (not task_points) and metadata.points then
+        task_points = metadata.points
+      end
+    end
+  end
+  if can_flatten then
+    if (not intro_points) and task_points then
+      attr = attr .. ' points="' .. task_points .. '"'
+      lines[1] = indent_line("<exercise" .. attr .. ">", indent)
+    end
+    if #flattened_parts > 0 then
+      table.insert(lines, indent_line("<statement>", indent + 1))
+      for _, part in ipairs(flattened_parts) do
+        if part.type == "p" then
+          local para = render_paragraph(part.content, indent + 2)
+          if para then table.insert(lines, para) end
+        elseif part.type == "list" then
+          table.insert(lines, render_plain_list(part.tag, part.content, indent + 2))
+        end
+      end
+      table.insert(lines, indent_line("</statement>", indent + 1))
+    end
+    for _, choice in ipairs(flattened_choices) do
+      local rendered = render_choices(choice.content, indent + 1, choice.forced_mode)
+      if rendered and rendered ~= "" then
+        table.insert(lines, rendered)
+      end
+    end
+    for _, hint_text in ipairs(flattened_hints) do
+      table.insert(lines, indent_line("<hint>", indent + 1))
+      local para = render_paragraph(hint_text, indent + 2)
+      if para then table.insert(lines, para) end
+      table.insert(lines, indent_line("</hint>", indent + 1))
+    end
+  else
+    if #intro_blocks > 0 then
+      table.insert(lines, indent_line("<introduction>", indent + 1))
+      for _, content in ipairs(intro_blocks) do
+        local para = render_paragraph(content, indent + 2)
+        if para then table.insert(lines, para) end
+      end
+      table.insert(lines, indent_line("</introduction>", indent + 1))
+    end
+    for _, result in ipairs(task_results) do
+      table.insert(lines, result.markup)
+    end
   end
   table.insert(lines, indent_line("</exercise>", indent))
   return table.concat(lines, "\n")

--- a/source/Fall 2023/Final.ptx
+++ b/source/Fall 2023/Final.ptx
@@ -7,422 +7,362 @@
 			</p>
 	</introduction>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Select the function graphed below.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)=-2(x+2)^2-1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)=2(x+2)^2+1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)=-2(x-2)^2-1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)=-2(x-2)^2+1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)=-2(x+2)^2-1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)=2(x+2)^2+1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)=-2(x-2)^2-1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)=-2(x-2)^2+1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Determine which rational function could generate the graph below.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>\dfrac{x^2-3x}{x-1}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>\dfrac{x^2+3x}{x-1}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>\dfrac{x^2+3x}{x^2-1}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>\dfrac{x^2+3x}{x^3-1}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>\dfrac{x^2-3x}{x-1}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>\dfrac{x^2+3x}{x-1}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>\dfrac{x^2+3x}{x^2-1}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>\dfrac{x^2+3x}{x^3-1}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following inequality. <me>2(3x-5)\geq 10</me>
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>\left(-\infty,\dfrac{10}{3}\right]</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>\left[\dfrac{10}{3},\infty\right)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>\left(-\infty,\dfrac{10}{3}\right)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>\left(\dfrac{10}{3},\infty\right)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>\left(-\infty,\dfrac{10}{3}\right]</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>\left[\dfrac{10}{3},\infty\right)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>\left(-\infty,\dfrac{10}{3}\right)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>\left(\dfrac{10}{3},\infty\right)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider quadratic, <m>f(x)=ax^2+bx+c</m>. What are we guaranteed about the zeros (roots) of the quadratic.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)</m> will have two integer roots (not necessarily distinct).
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)</m> will have two rational roots (not necessarily distinct).
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)</m> will have two real roots (not necessarily distinct).
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)</m> is not guaranteed to have any real roots.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)</m> will have two integer roots (not necessarily distinct).
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)</m> will have two rational roots (not necessarily distinct).
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)</m> will have two real roots (not necessarily distinct).
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)</m> is not guaranteed to have any real roots.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Select the graph below that is not a function.
 			</p>
-		</introduction>
-		<task workspace="-.7cm">
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find all solutions to the following equation. <me>x^3=x</me>
 			</p>
 			<p>
 				Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>x=1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=1</m>, <m>x=0</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=1</m>, <m>x=-1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=1</m>, <m>x=-1</m>, <m>x=0</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=i</m>, <m>x=-i</m>, <m>x=1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>x=1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=1</m>, <m>x=0</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=1</m>, <m>x=-1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=1</m>, <m>x=-1</m>, <m>x=0</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=i</m>, <m>x=-i</m>, <m>x=1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following inequality. <me>2|3-x|\geq 1</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Write a polynomial, <m>P(x)</m> with roots of <m>-3</m>, <m>6</m>, a repeated root at <m>11</m> with multiplicity 3, and as <m>x\to -\infty</m>, <m>P(x)\to +\infty</m> and as <m>x\to +\infty</m>, <m>P(x)\to -\infty</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>f(x) = x^2 - x - 20</m>.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Find all the roots of <m>f(x)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Let <m>g(x) = x^2</m>, find <m>(f \circ g)(x)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What are all the possible <term>rational roots</term> of <m>(f \circ g)(x)</m> according to the <term>rational root theorem</term>?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Using Part (a) of the question, find all the <term>roots</term> of <m>(f \circ g)(x)</m>. Credit will be given solely based on whether the answer is correct. (<term>Hint</term>: Some of the roots are complex numbers).
-				</p>
-			</statement>
-		</task>
+			<p>
+				Find all the roots of <m>f(x)</m>.
+			</p>
+			<p>
+				Let <m>g(x) = x^2</m>, find <m>(f \circ g)(x)</m>.
+			</p>
+			<p>
+				What are all the possible <term>rational roots</term> of <m>(f \circ g)(x)</m> according to the <term>rational root theorem</term>?
+			</p>
+			<p>
+				Using Part (a) of the question, find all the <term>roots</term> of <m>(f \circ g)(x)</m>. Credit will be given solely based on whether the answer is correct. (<term>Hint</term>: Some of the roots are complex numbers).
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Expand the following log function with no interior multiplications or divisions and simplified powers as much as the log rules allow <me>\ln \frac{x^3y}{\sqrt{x-y}}.</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Perform the following operation and write as a single fraction. <me>\frac{x}{x+2}+\frac{x-3}{x^2+7x+10}</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>f(x)=\log_2(3-x)</m>.
 			</p>
-		</introduction>
-		<task workspace="5cm">
-			<statement>
-				<p>
-					Find the domain of <m>f(x)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find the zero of <m>f(x)</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Compute the inverse function <m>f^{-1}(x)</m>.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Find the domain of <m>f(x)</m>.
+			</p>
+			<p>
+				Find the zero of <m>f(x)</m>
+			</p>
+			<p>
+				Compute the inverse function <m>f^{-1}(x)</m>.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				For each of the following systems of linear equations, determine whether or not the system has any solutions. For the systems that have solutions, find all solutions; for the systems that have infinitely many solutions, write your solutions as an ordered pair in terms of the variable <m>x</m> only.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					<me>\begin{aligned}
-											        5 x  -  y &amp;= 5 \\
-											          x  +  3y &amp;= -7
-											    
-											\end{aligned}</me>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					<me>\begin{aligned}
-											        2x - 2y &amp;= 3 \\
-											        -4x + 4y &amp;= -6
-											    
-											\end{aligned}</me>
-				</p>
-			</statement>
-		</task>
+			<p>
+				<me>\begin{aligned}
+										        5 x  -  y &amp;= 5 \\
+										          x  +  3y &amp;= -7
+										    
+										\end{aligned}</me>
+			</p>
+			<p>
+				<me>\begin{aligned}
+										        2x - 2y &amp;= 3 \\
+										        -4x + 4y &amp;= -6
+										    
+										\end{aligned}</me>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the rational function <me>f(x)=\frac{2x+5}{x^2+2x-35}</me>
 			</p>
-		</introduction>
-		<task workspace="4cm">
-			<statement>
-				<p>
-					Find the zeroes of <m>f</m>.
-				</p>
-			</statement>
-		</task>
-		<task workspace="4cm">
-			<statement>
-				<p>
-					Find the vertical asymptotes of <m>f</m>.
-				</p>
-			</statement>
-		</task>
-		<task workspace="2cm">
-			<statement>
-				<p>
-					Solve the following inequality and put your final answers in interval notation.<me>\frac{2x+5}{x^2+2x-35}\geq 0</me>
-				</p>
-			</statement>
-		</task>
+			<p>
+				Find the zeroes of <m>f</m>.
+			</p>
+			<p>
+				Find the vertical asymptotes of <m>f</m>.
+			</p>
+			<p>
+				Solve the following inequality and put your final answers in interval notation.<me>\frac{2x+5}{x^2+2x-35}\geq 0</me>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the complete solution of the linear system, or show that it has no solution. <me>\left\{
 							    \begin{aligned}
@@ -431,27 +371,27 @@
 							        5x-3y-6z&amp;=10\\
 							    \end{aligned}\right.</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the domain of the function
 			</p>
 			<p>
 				<me>f(x) = \sqrt{2+x} + \dfrac{1}{\sqrt{2-x}}</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the solution(s) to the following equation. <me>\log_2(x+7)+\log_2(x)=3</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				This problem involves the radioactive decay model, <m>A(t)=A_, e^{-kt}</m>
 			</p>
@@ -464,16 +404,16 @@
 			<p>
 				Find the value of <m>k</m> in the radioactive decay model. (Leave it in terms of a log.)
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				A population of 20 cats is sent to a moon habitat and the population begins to grow. The number of moon-cats is modelled by <m>n(t)=P_0 e^{0.21t}</m>, with <m>t</m> measured in years.
 			</p>
 			<p>
 				How many years will it take for there to be 5000 moon-cats? (Leave your answer in terms of a log.)
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 </worksheet>

--- a/source/Fall 2023/Midterm1.ptx
+++ b/source/Fall 2023/Midterm1.ptx
@@ -7,383 +7,321 @@
 			</p>
 	</introduction>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				The number <m>i^{7}</m> is equal to
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>i</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-i</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the Above
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>i</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>-1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>-i</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the Above
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				The domain of <m>\dfrac{1}{\sqrt{x+4}}</m> is:
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty,-4]</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty, -4)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[-4,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(-4,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x\ge 0</m>
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>(-\infty,-4]</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>(-\infty, -4)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>[-4,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>(-4,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x\ge 0</m>
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Select the correct graph of <m>f(x)=\left\{\begin{matrix}
 							    x^2 &amp;,&amp; x\ge 0\\
 							    2x &amp;,&amp; x&lt;0
 							\end{matrix}\right.</m>
 			</p>
-		</introduction>
-		<task workspace="-.7cm">
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Determine whether the curve below represents a function.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								Function: The graph passes the horizontal line test.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								Not a Function: The graph fails the horizontal line test.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								Not a Function: The graph fails the vertical line test.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								Function: The graph passes the vertical line test.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								We cannot tell from the graph whether or not it represents a function.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						Function: The graph passes the horizontal line test.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						Not a Function: The graph fails the horizontal line test.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						Not a Function: The graph fails the vertical line test.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						Function: The graph passes the vertical line test.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						We cannot tell from the graph whether or not it represents a function.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find all <term>real</term> solutions to the following equation. <me>x^4=9x^2</me>
 			</p>
 			<p>
 				Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>x=\sqrt{3},\, x=-\sqrt{3}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=3,\,x=3</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=0,\,x=\sqrt{3},\,x=-\sqrt{3}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=0,\,x=3,\,x=-3</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the Above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>x=\sqrt{3},\, x=-\sqrt{3}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=3,\,x=3</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=0,\,x=\sqrt{3},\,x=-\sqrt{3}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=0,\,x=3,\,x=-3</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the Above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Perform the operation and write the answer as a single polynomial.
 			</p>
 			<p>
 				<me>(3x-5)(x+3)=</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Perform the following operations and simplify. Your final answer should be written as a single fraction and contain no common factors in the numerator and denominator. <me>\dfrac{x-2}{x^2-9} -\dfrac{1}{5x+15}</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following equations for all solutions.
 			</p>
-		</introduction>
-		<task workspace="1.1in">
-			<statement>
-				<p>
-					<m>\dfrac{1+3x}{x+2}=5</m>
-				</p>
-			</statement>
-		</task>
-		<task workspace="1.1in">
-			<statement>
-				<p>
-					<m>\sqrt{2x+5}=x+1</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				<m>\dfrac{1+3x}{x+2}=5</m>
+			</p>
+			<p>
+				<m>\sqrt{2x+5}=x+1</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following inequalities.
 			</p>
-		</introduction>
-		<task workspace="1.1in">
-			<statement>
-				<p>
-					<m>3\ge -4x-7 &gt;-7</m>
-				</p>
-			</statement>
-		</task>
-		<task workspace="1.1in">
-			<statement>
-				<p>
-					<m>x^2-21x+20\ge0</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				<m>3\ge -4x-7 &gt;-7</m>
+			</p>
+			<p>
+				<m>x^2-21x+20\ge0</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following for <m>x</m>.
 			</p>
 			<p>
 				<m>5-3|x+2|=2</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Plot the following points.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					<m>A(3, 0),\, B(-4,5)</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What is the distance between the points <m>A</m> and <m>B</m>? (You may leave it as a square root.)
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What is the slope of the line through <m>A</m> and <m>B</m>?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What is an equation of the line through <m>A</m> and <m>B</m>?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What is the equation of the line through <m>(2,-3)</m> perpendicular to the line through <m>A</m> and <m>B</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				<m>A(3, 0),\, B(-4,5)</m>
+			</p>
+			<p>
+				What is the distance between the points <m>A</m> and <m>B</m>? (You may leave it as a square root.)
+			</p>
+			<p>
+				What is the slope of the line through <m>A</m> and <m>B</m>?
+			</p>
+			<p>
+				What is an equation of the line through <m>A</m> and <m>B</m>?
+			</p>
+			<p>
+				What is the equation of the line through <m>(2,-3)</m> perpendicular to the line through <m>A</m> and <m>B</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				What is the average rate of change of <m>f(x)=3x^2-5x</m> between <m>x=-2</m> and <m>x=1</m>?
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the function <m>f(x)=\sqrt{2x^2-5x}</m>. Let <m>g(x)=f(-3x)</m>.
 			</p>
 			<p>
 				Write down an expression of <m>g(x)</m>.
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the graphs of functions <m>f(x)</m> and <m>g(x)</m> as shown below. (Note: <m>f</m> is a curve, <m>g</m> is straight lines with a corner.)
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					The range of <m>g</m>
-				</p>
-			</statement>
-		</task>
-		<task workspace="2in">
-			<statement>
-				<p>
-					Intervals on which <m>f</m> is increasing
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					A local max for <m>f</m> in the interval <m>(-2,2)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Interval(s) in <m>x</m> for which <m>f(x)&gt;g(x)</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				The range of <m>g</m>
+			</p>
+			<p>
+				Intervals on which <m>f</m> is increasing
+			</p>
+			<p>
+				A local max for <m>f</m> in the interval <m>(-2,2)</m>.
+			</p>
+			<p>
+				Interval(s) in <m>x</m> for which <m>f(x)&gt;g(x)</m>
+			</p>
+		</statement>
 	</exercise>
 </worksheet>

--- a/source/Fall 2023/Midterm2.ptx
+++ b/source/Fall 2023/Midterm2.ptx
@@ -7,398 +7,320 @@
 			</p>
 	</introduction>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Select a polynomial of smallest degree with roots of <m>6</m>, <m>\sqrt{7}</m>, a repeated root of <m>-3</m> with a multiplicity of <m>2</m>, and a leading coefficient of <m>-5</m>.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>(x-6)(x-\sqrt{7})(x+3)^2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-5(x-6)(x-\sqrt{7})(x+3)^2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(x+6)(x+\sqrt{7})(x-3)^2(x-5)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-5(x+6)(x+\sqrt{7})(x-3)^2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>(x-6)(x-\sqrt{7})(x+3)^2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>-5(x-6)(x-\sqrt{7})(x+3)^2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>(x+6)(x+\sqrt{7})(x-3)^2(x-5)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>-5(x+6)(x+\sqrt{7})(x-3)^2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				You run a business teaching aspiring didgeridoo players. Let <m>x</m> be the number of hours you spend teaching your students. If the equation for your profit (in dollars) is given by <me>P(x) = 28 x-35</me> What is the rate of change and what does it represent in this equation?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								You earn $28 dollars per hour teaching.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								You make 28 didgeridoos per hour.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								You lose $35 dollars per hour teaching.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=\dfrac{5}{4}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						You earn $28 dollars per hour teaching.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						You make 28 didgeridoos per hour.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						You lose $35 dollars per hour teaching.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=\dfrac{5}{4}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider a polynomial <me>P(x) = ax^7+3x^5-4x+12</me> You do not know <m>a</m>, but you know as <m>x\to-\infty</m> <m>P(x)\to+\infty</m>. What else do you know?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								As <m>x\to+\infty</m>  <m>P(x)\to+\infty</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>P(x)</m> has seven rational roots.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								As <m>x\to+\infty</m>  <m>P(x)\to-\infty</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>P(x)</m> has seven real roots.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						As <m>x\to+\infty</m>  <m>P(x)\to+\infty</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>P(x)</m> has seven rational roots.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						As <m>x\to+\infty</m>  <m>P(x)\to-\infty</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>P(x)</m> has seven real roots.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Given the graph of <m>f(x)=2^x</m> below, select the correct graph of <m>g(x)=\dfrac{1}{4}2^{-x}+1</m>
 			</p>
-		</introduction>
-		<task workspace="-.7cm">
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				of the functions graphed below which would have an inverse function.
 			</p>
 			<p>
 				Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
 			</p>
-		</introduction>
-		<task workspace="-.7cm">
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				The graph of a function <m>y = f(x)</m> is displayed below:
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				[4] Given the graphs of functions <m>f(x)</m> and <m>g(x)</m> below, find <m>f\circ g(1)</m>.
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>f(x)=\frac{1}{x}+x</m> and <m>g(x)=x^2+1</m>.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Find <m>f\circ g(x)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find <m>f\circ f(x)</m>.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Find <m>f\circ g(x)</m>.
+			</p>
+			<p>
+				Find <m>f\circ f(x)</m>.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>f(x)=\sqrt{x^3-1}</m>.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Find the domain of function <m>f(x)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find the inverse <m>f^{-1}(x)</m>.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Find the domain of function <m>f(x)</m>.
+			</p>
+			<p>
+				Find the inverse <m>f^{-1}(x)</m>.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				A manufacturer finds that the revenue generated by selling <m>x</m> units of a certain commodity is given by the function <me>R(x) = 40 x - 5 x^2 \,.</me>
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Write the function <m>R(x)</m> in vertex form.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What is the maximum possible revenue generated?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					How many units should be manufactured to obtain the maximum revenue?
-				</p>
-			</statement>
-		</task>
+			<p>
+				Write the function <m>R(x)</m> in vertex form.
+			</p>
+			<p>
+				What is the maximum possible revenue generated?
+			</p>
+			<p>
+				How many units should be manufactured to obtain the maximum revenue?
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>f(x) = -3(x+1)(x-4)^3</m> be a polynomial function.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Fill in the blanks with the end behavior of <m>f(x)</m>.
-				</p>
-				<p>
-					(No justification is needed.)
-				</p>
-				<p>
-					As <m>x \to \infty</m>, <m>y \to</m>
-				</p>
-				<p>
-					.
-				</p>
-				<p>
-					As <m>x \to -\infty</m>, <m>y \to</m>
-				</p>
-				<p>
-					.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find the <m>x</m>-intercepts (zeroes) of the function <m>f(x)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Using part (b) and (c), sketch the graph of <m>f(x)</m> on the <m>xy</m>-plane provided below. You need to clearly indicate the <m>x</m>-intercepts of <m>f(x)</m> to receive full credit.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Fill in the blanks with the end behavior of <m>f(x)</m>.
+			</p>
+			<p>
+				(No justification is needed.)
+			</p>
+			<p>
+				As <m>x \to \infty</m>, <m>y \to</m>
+			</p>
+			<p>
+				.
+			</p>
+			<p>
+				As <m>x \to -\infty</m>, <m>y \to</m>
+			</p>
+			<p>
+				.
+			</p>
+			<p>
+				Find the <m>x</m>-intercepts (zeroes) of the function <m>f(x)</m>.
+			</p>
+			<p>
+				Using part (b) and (c), sketch the graph of <m>f(x)</m> on the <m>xy</m>-plane provided below. You need to clearly indicate the <m>x</m>-intercepts of <m>f(x)</m> to receive full credit.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>P(x)=5x^4+2x^2-x+1</m> and <m>D(x)=x^2-x+2</m>.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Divide <m>P(x)</m> by <m>D(x)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Express <m>P(x)</m> in the form <m>D(x)\cdot Q(x)+R(x)</m>.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Divide <m>P(x)</m> by <m>D(x)</m>.
+			</p>
+			<p>
+				Express <m>P(x)</m> in the form <m>D(x)\cdot Q(x)+R(x)</m>.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>g(x) = 3x^{3}+7x^{2}-7x-3</m>.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					What are all the possible rational roots of <m>g(x)</m> according to the rational root theorem?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					If we know that <m>g(x)</m> has a root at <m>x=-3</m>, find all the roots of <m>g(x)</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Write <m>g(x)</m> as a product of linear factors.
-				</p>
-			</statement>
-		</task>
+			<p>
+				What are all the possible rational roots of <m>g(x)</m> according to the rational root theorem?
+			</p>
+			<p>
+				If we know that <m>g(x)</m> has a root at <m>x=-3</m>, find all the roots of <m>g(x)</m>
+			</p>
+			<p>
+				Write <m>g(x)</m> as a product of linear factors.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				For this problem, leave your answers in terms of an exponential. (Please do not try to expand the exponential or calculate the final values.)
 			</p>
 			<p>
 				Suppose you invest $10,000 in a fund with 6% annual interest. Write an expression for the amount of money in the account after 5 years if interest is compounded:
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Quarterly (<m>n=4</m> times per year)
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Continuously
-				</p>
-			</statement>
-		</task>
+			<p>
+				Quarterly (<m>n=4</m> times per year)
+			</p>
+			<p>
+				Continuously
+			</p>
+		</statement>
 	</exercise>
 </worksheet>

--- a/source/Fall 2024/Final.ptx
+++ b/source/Fall 2024/Final.ptx
@@ -7,355 +7,317 @@
 			</p>
 	</introduction>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following quadratic equation:<!-- linebreak --><me>x^2+9=0</me> [Select <term>ONE</term>]
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>x=-3</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=3</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=3</m> or <m>x=-3</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=3i</m> or <m>x=-3i</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								The equation has no solution.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>x=-3</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=3</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=3</m> or <m>x=-3</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=3i</m> or <m>x=-3i</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						The equation has no solution.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Select the equation of the line through <m>(-2 , 3)</m> <term>parallel</term> to the line <m>y=-2x+1</m>. [Select <term>ONE</term>]
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>y + 3=-2(x-2)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y - 3=-2(x+2)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y + 3=\frac{1}{2}(x-2)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y - 3=\frac{1}{2}(x+2)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>y + 3=-2(x-2)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y - 3=-2(x+2)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y + 3=\frac{1}{2}(x-2)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y - 3=\frac{1}{2}(x+2)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Select all real solutions to the equation <m>\sqrt{7-2x}+1=2x</m>. [Select <term>One or more</term>]
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="yes">
-					<choice>
-						<statement>
-							<p>
-								A. <m>x=-1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								B. <m>x=1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								C. <m>x=\frac{3}{2}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								D. <m>x=-\frac{3}{2}</m>
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="yes">
+			<choice>
+				<statement>
+					<p>
+						A. <m>x=-1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						B. <m>x=1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						C. <m>x=\frac{3}{2}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						D. <m>x=-\frac{3}{2}</m>
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Select the function graphed below. [Select <term>ONE</term>]
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								A. <m>f(x)=-2(x+2)^2-2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								B. <m>f(x)=2(x+2)^2+2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								C. <m>f(x)=2(x-2)^2-2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								D. <m>f(x)=2(x-2)^2+2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								E. None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						A. <m>f(x)=-2(x+2)^2-2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						B. <m>f(x)=2(x+2)^2+2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						C. <m>f(x)=2(x-2)^2-2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						D. <m>f(x)=2(x-2)^2+2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						E. None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Determine where the function is increasing. [Select <term>ONE</term>]
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								A. <m>(-\infty,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								B. <m>(-\infty,-1)\cup (3,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								C. <m>(3,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								D. <m>(-\infty,1)\cup (1,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								E. None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						A. <m>(-\infty,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						B. <m>(-\infty,-1)\cup (3,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						C. <m>(3,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						D. <m>(-\infty,1)\cup (1,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						E. None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Select the graph of the function below. [Select <term>ONE</term>] <me>f(x)=(x+2)^2(x+1)(x-1).</me>
 			</p>
 			<p>
 				Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following inequality and write your answers using interval notation. <me>|2x+3|+1 \leq 6</me>.
 			</p>
 			<p>
 				<m>\mbox{Solution: } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{8cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Expand the logs with no interior multiplications or divisions and simplified powers as much as the rules allow. <me>\ln \frac{y^2}{\sqrt{2^x (z+x)^3}}</me>
 			</p>
 			<p>
 				<m>\ln \frac{y^2}{\sqrt{2^x (z+x)^3}}= \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{8cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the function <m>f(x)=\dfrac{2x-5}{x+4}</m>. (Graph shown below.)
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					What is the domain and range of <m>f(x)</m>? (Write in interval notation.)
-				</p>
-				<p>
-					<m>\mbox{Domain: } \scalebox{1.7}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m><!-- linebreak --><m>\mbox{Range: } \scalebox{1.7}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What are the domain and range of <m>f^{-1}(x)</m>? (Write in interval notation.)
-				</p>
-				<p>
-					<m>\mbox{Domain: } \scalebox{1.7}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m><!-- linebreak --><m>\mbox{Range: } \scalebox{1.7}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What is <m>f^{-1}(x)</m>? <m>f^{-1}(x) = \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				What is the domain and range of <m>f(x)</m>? (Write in interval notation.)
+			</p>
+			<p>
+				<m>\mbox{Domain: } \scalebox{1.7}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m><!-- linebreak --><m>\mbox{Range: } \scalebox{1.7}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m>
+			</p>
+			<p>
+				What are the domain and range of <m>f^{-1}(x)</m>? (Write in interval notation.)
+			</p>
+			<p>
+				<m>\mbox{Domain: } \scalebox{1.7}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m><!-- linebreak --><m>\mbox{Range: } \scalebox{1.7}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m>
+			</p>
+			<p>
+				What is <m>f^{-1}(x)</m>? <m>f^{-1}(x) = \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the rational function <me>f(x)= \dfrac{x^3-13 x^2+40 x+18}{ x^2-7x}</me>
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Perform the division and write <m>f(x)</m> as <m>f(x)= Q(x)+\dfrac{R(x)}{D(x)}</m>
-				</p>
-				<p>
-					<m>f(x) = \scalebox{2}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{6cm} }}}</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Does <m>f(x)</m> have a slant asymptote? If so what is it? If not write “DNE".
-				</p>
-				<p>
-					<m>\mbox{slant asymptote: }   \scalebox{1.7}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{4cm} }}}</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				Perform the division and write <m>f(x)</m> as <m>f(x)= Q(x)+\dfrac{R(x)}{D(x)}</m>
+			</p>
+			<p>
+				<m>f(x) = \scalebox{2}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{6cm} }}}</m>
+			</p>
+			<p>
+				Does <m>f(x)</m> have a slant asymptote? If so what is it? If not write “DNE".
+			</p>
+			<p>
+				<m>\mbox{slant asymptote: }   \scalebox{1.7}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{4cm} }}}</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				A basketball player throws a half court shot. Let <m>t</m> denote the time taken (in seconds) after the ball was released. At <m>t=0</m>, they release the ball at the height of 10ft. At <m>t=2</m>, the ball reaches the basket, which is also 10ft high. The height of the ball <m>h</m> (in ft) can be modeled by the following equation: <me>h(t)=a(t-1)^2+k.</me>
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					It is given that the maximum height of the ball is 15ft. Based on the information above, find the values of <m>a</m> and <m>k</m> in the equation of <m>h(t)</m>.
-				</p>
-				<p>
-					<m>a</m> = , <m>k</m> =
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What time <m>t</m> will the ball reach its maximum height?<!-- linebreak --><m>t = \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{2cm} }}}</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				It is given that the maximum height of the ball is 15ft. Based on the information above, find the values of <m>a</m> and <m>k</m> in the equation of <m>h(t)</m>.
+			</p>
+			<p>
+				<m>a</m> = , <m>k</m> =
+			</p>
+			<p>
+				What time <m>t</m> will the ball reach its maximum height?<!-- linebreak --><m>t = \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{2cm} }}}</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find all roots of the polynomial: <m>x^4 + x^2 - 12</m>. (Roots may be real, complex or a combination.)
 			</p>
 			<p>
 				<m>\mbox{Roots: } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{8cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find all values of <m>x</m> that satisfy the following inequality:
 			</p>
@@ -365,20 +327,20 @@
 			<p>
 				Interval: <m>\scalebox{1.7}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{6cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following equation. If no solution exists, write <q>DNE</q>. <me>\log_2 (x-1)+\log_2 (x+6)=3</me>
 			</p>
 			<p>
 				<m>x = \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				For the following system of linear equations, determine whether or not the system has any solutions. If the system has a solution, state it as an ordered pair <m>(x,y)</m>; if the systems has infinitely many solutions, write your solutions as an ordered pair in terms of the variable <m>x</m> only. <me>\begin{cases}
 							3 x  +  4 y &amp; = 1 \\
@@ -388,82 +350,78 @@
 			<p>
 				<m>(x,y) = \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the function <me>f(x) = \frac{(2x+1)(x-2)}{3x(x-2)(x+3)^2}</me>
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								Find the zero(s) of <m>f(x)</m>. If none exist, write “DNE".
-							</p>
-							<p>
-								<m>\mbox{zero(s)} = \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								Find the vertical asymptote(s) of <m>f(x)</m>. If none exist, write “DNE".
-							</p>
-							<p>
-								<m>\mbox{Vertical Asymptotes} = \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								What can we say about the graph of f(x)? [Select <term>ONE</term>]
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								Sketch this function on the axis below. Make sure to label ,  and  on your sketch.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						Find the zero(s) of <m>f(x)</m>. If none exist, write “DNE".
+					</p>
+					<p>
+						<m>\mbox{zero(s)} = \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						Find the vertical asymptote(s) of <m>f(x)</m>. If none exist, write “DNE".
+					</p>
+					<p>
+						<m>\mbox{Vertical Asymptotes} = \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{3cm} }}}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						What can we say about the graph of f(x)? [Select <term>ONE</term>]
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						Sketch this function on the axis below. Make sure to label ,  and  on your sketch.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				A group of scientists are trying to develop a treatment to stop the planarians from growing.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								Sample A starts with 1000 planarians, and 2 hours later there are 200 planarians. Find a function <m>P(t)=P_0e^{rt}</m> that models the population of the planarians after <m>t</m> hours. (Leave the value for <m>r</m> in terms of a <m>\log</m>) <me>\begin{aligned}
-														                \scalebox{1.7}{\ensuremath{\boxed{P(t) =\phantom{\frac{1}{2}} \hspace{4cm} }}}
-														            
-														\end{aligned}</me>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								The scientists find that the number of planarians in sample B <m>t</m> hours after treatment is best modeled by the function <me>P(t) = 800 e^{0.5\ln(1/3)t}.</me> Is this function increasing or decreasing? [Select <term>ONE</term>]
-							</p>
-							<p>
-								Explain how you know based on this model.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						Sample A starts with 1000 planarians, and 2 hours later there are 200 planarians. Find a function <m>P(t)=P_0e^{rt}</m> that models the population of the planarians after <m>t</m> hours. (Leave the value for <m>r</m> in terms of a <m>\log</m>) <me>\begin{aligned}
+												                \scalebox{1.7}{\ensuremath{\boxed{P(t) =\phantom{\frac{1}{2}} \hspace{4cm} }}}
+												            
+												\end{aligned}</me>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						The scientists find that the number of planarians in sample B <m>t</m> hours after treatment is best modeled by the function <me>P(t) = 800 e^{0.5\ln(1/3)t}.</me> Is this function increasing or decreasing? [Select <term>ONE</term>]
+					</p>
+					<p>
+						Explain how you know based on this model.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 </worksheet>

--- a/source/Fall 2024/Midterm1.ptx
+++ b/source/Fall 2024/Midterm1.ptx
@@ -2,336 +2,316 @@
 <worksheet xml:id="Fall-2024-Midterm1" xmlns:xi="http://www.w3.org/2001/XInclude">
 	<title>Fall-2024-Midterm1</title>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find an equation for the line which is perpendicular to and has the same <m>y</m>-intercept as the line <m>y=-2x+\frac{1}{3}</m>
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>y=2x+\frac{1}{3}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=-2x-3</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=\frac{1}{2}x-3</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=\frac{1}{2}x+\frac{1}{3}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>y=2x+\frac{1}{3}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y=-2x-3</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y=\frac{1}{2}x-3</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y=\frac{1}{2}x+\frac{1}{3}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				<term>Select ALL</term> of the following that are functions:
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="yes">
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="yes">
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				<term>Select ALL</term> (real and complex) solutions to the equation: <me>x^4-1=0</me>
 			</p>
-		</introduction>
-		<task workspace="-.7cm">
-				<choices multiple-correct="yes">
-					<choice>
-						<statement>
-							<p>
-								<m>x=0</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=-1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=i</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=-i</m>
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="yes">
+			<choice>
+				<statement>
+					<p>
+						<m>x=0</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=-1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=i</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=-i</m>
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the domain of the function: <me>\dfrac{\sqrt{x+5}}{x-4}</me>
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty, -5)\bigcup(-5,4)\bigcup(4,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty, 4)\bigcup(4,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[-5,4)\bigcup(4,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty, -5]\bigcup[5,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the Above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>(-\infty, -5)\bigcup(-5,4)\bigcup(4,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>(-\infty, 4)\bigcup(4,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>[-5,4)\bigcup(4,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>(-\infty, -5]\bigcup[5,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the Above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the solution to the following inequality <me>|x-2|\le-2</me>
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty,0]\cup[4,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								There is no <m>x</m> that solves the inequality.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[0,4]</m>
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>(-\infty,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>(-\infty,0]\cup[4,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						There is no <m>x</m> that solves the inequality.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>[0,4]</m>
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Gilbert is solving a quadratic using completing the square. He has isolated the <m>x</m>-terms on one side of the equation to find: <me>x^2-6x=2</me> What does he  of the equation in the next step of completing the square?
 			</p>
 			<p>
 				Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								3
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								9
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-9</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						3
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						9
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>-9</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>-2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Evaluate the following. (In your final answer, make sure that the numerator and the denominator do not contain a common factor other than 1.)
 			</p>
 			<p>
 				<m>\displaystyle{\frac{x+2}{x^2+4x+3}+\frac{x+3}{2x+2}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Factor the following quadratic. <m>5 x^2+14 x-3</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve for <m>x</m>: <me>x^2 + 10x +50 = 1-4x</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve for <m>x</m>: <me>x^2+2x-9=0</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the points <m>A=(1,1)</m> and <m>B=(4,3)</m>.
 			</p>
 			<p>
 				Find an equation for the line passing through the points <m>A</m> and <m>B</m>. Give your answer in point-slope form.
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following inequality (Give your answer in interval notation): <me>|6-3x|-2\geq 7</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find <term>all</term> solutions to the following equation: <me>x^4 -11x^2  +18= 0.</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve each of the following inequalities. For each part, express your answer in interval notation.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					<m>-9\le4-5x&lt;6</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					<m>-2x^2\ge-7x+6</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				<m>-9\le4-5x&lt;6</m>
+			</p>
+			<p>
+				<m>-2x^2\ge-7x+6</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Draw a graph of the following function, for <m>-5 \le x \le 5</m>:
 			</p>
@@ -342,66 +322,48 @@
 							-2 &amp; 2 &lt; x \\
 							\end{cases}</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Below is a graph of the water temperatures of Lake Mendota (<m>f(x)</m>, curved, solid line) and Lake Michigan (<m>g(x)</m>, pointy, dashed line) over the course of one year.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					What is the  of <m>g</m>?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What are the interval(s) where the temperature of Lake Mendota (<m>f(x)</m>) is decreasing?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					<term>Identify all</term> local minima of <m>g(x)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What days (<m>x</m> values) do the two lakes have the same temperature (i.e. for what <m>x</m> is <m>f(x) = g(x)</m>)
-				</p>
-			</statement>
-		</task>
+			<p>
+				What is the  of <m>g</m>?
+			</p>
+			<p>
+				What are the interval(s) where the temperature of Lake Mendota (<m>f(x)</m>) is decreasing?
+			</p>
+			<p>
+				<term>Identify all</term> local minima of <m>g(x)</m>.
+			</p>
+			<p>
+				What days (<m>x</m> values) do the two lakes have the same temperature (i.e. for what <m>x</m> is <m>f(x) = g(x)</m>)
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the average rate of change for functions below on indicated intervals.
 			</p>
-		</introduction>
-		<task workspace="1cm">
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>f(x) = \dfrac{x^2}{2\sqrt{x + 6}}</m> on <m>[-5,10]</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								Below is the graph of a function <m>g</m>. Of the three choices below, choose the interval where <m>g(x)</m> has the .
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>f(x) = \dfrac{x^2}{2\sqrt{x + 6}}</m> on <m>[-5,10]</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						Below is the graph of a function <m>g</m>. Of the three choices below, choose the interval where <m>g(x)</m> has the .
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 </worksheet>

--- a/source/Fall 2024/Midterm2.ptx
+++ b/source/Fall 2024/Midterm2.ptx
@@ -7,234 +7,212 @@
 			</p>
 	</introduction>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Which of the following functions have inverse functions? [Select <term>MULTIPLE</term>]
 			</p>
-		</introduction>
-		<task workspace="-.7cm">
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								A.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								B.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								C.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								D.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						A.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						B.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						C.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						D.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				A polynomial has a leading term of <m>-3x^4</m>. What is the end behavior of this polynomial? [Select <term>ONE</term>]
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								As <m>x\to +\infty</m>, <m>y\to -\infty</m> and as <m>x\to -\infty</m>, <m>y\to +\infty</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								As <m>x\to +\infty</m>, <m>y\to +\infty</m> and as <m>x\to -\infty</m>, <m>y\to +\infty</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								As <m>x\to +\infty</m>, <m>y\to -\infty</m> and as <m>x\to -\infty</m>, <m>y\to -\infty</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								As <m>x\to +\infty</m>, <m>y\to +\infty</m> and as <m>x\to -\infty</m>, <m>y\to -\infty</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						As <m>x\to +\infty</m>, <m>y\to -\infty</m> and as <m>x\to -\infty</m>, <m>y\to +\infty</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						As <m>x\to +\infty</m>, <m>y\to +\infty</m> and as <m>x\to -\infty</m>, <m>y\to +\infty</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						As <m>x\to +\infty</m>, <m>y\to -\infty</m> and as <m>x\to -\infty</m>, <m>y\to -\infty</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						As <m>x\to +\infty</m>, <m>y\to +\infty</m> and as <m>x\to -\infty</m>, <m>y\to -\infty</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider a parabola <m>f(x)=ax^2+bx+c</m>. If the graph of <m>y=ax^2+bx+c</m> intersects the <m>x</m>-axis at two separate points, what can we say about the roots of <m>f(x)</m>? [Select <term>ONE</term>]
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								There are two real roots of <m>f(x)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								There may be either one or two real roots of <m>f(x)</m>, and we need more information to know.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								There are two complex roots of <m>f(x)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								There is exactly one real root of <m>f(x)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						There are two real roots of <m>f(x)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						There may be either one or two real roots of <m>f(x)</m>, and we need more information to know.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						There are two complex roots of <m>f(x)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						There is exactly one real root of <m>f(x)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Colt works as a stuntman in action movies. Let <m>x</m> be the number of hours he works. The equation for his money earned (in dollars) is given by <me>P(x) = 10 x-8.</me> What is the rate of change and what does it represent? [Select <term>ONE</term>]
 			</p>
 			<p>
 				<term>Short Answer</term>. Show your work; partial credit may be awarded.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								He earns 10 dollars per hour of work.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								He does 10 stunts per hour.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								He loses 8 dollars per hour of work.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=\dfrac{5}{4}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						He earns 10 dollars per hour of work.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						He does 10 stunts per hour.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						He loses 8 dollars per hour of work.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=\dfrac{5}{4}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the two graphs below of <m>f(x)</m> and <m>g(x)</m>.
 			</p>
-		</introduction>
-		<task workspace="7cm">
-			<statement>
-				<p>
-					Find <m>(g-f)(1) = \scalebox{5}{\ensuremath{\boxed{ \hspace{.3cm}}}}</m>
-				</p>
-			</statement>
-		</task>
-		<task workspace="5cm">
-			<statement>
-				<p>
-					Find <m>g\circ f (3) = \scalebox{5}{\ensuremath{\boxed{ \hspace{.3cm}}}}</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				Find <m>(g-f)(1) = \scalebox{5}{\ensuremath{\boxed{ \hspace{.3cm}}}}</m>
+			</p>
+			<p>
+				Find <m>g\circ f (3) = \scalebox{5}{\ensuremath{\boxed{ \hspace{.3cm}}}}</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Sketch the graph of the function <me>f(x)=(x+1)^3(x-1)^2(x-3).</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<task workspace=".5cm">
-			<statement>
-				<p>
-					Find the polynomial <m>h(x)</m> of least possible degree with  that has a repeated root of 3 with multiplicity 2 and a root of <m>\sqrt{2}</m> such that <m>h(0)=-36</m>.
-				</p>
-				<p>
-					(You may leave your answer as a product of linear factors.)
-				</p>
-			</statement>
-		</task>
-		<task workspace=".5cm">
-			<statement>
-				<p>
-					What is the leading term of the polynomial and what is the degree of the polynomial?
-				</p>
-			</statement>
-		</task>
+		<statement>
+			<p>
+				Find the polynomial <m>h(x)</m> of least possible degree with  that has a repeated root of 3 with multiplicity 2 and a root of <m>\sqrt{2}</m> such that <m>h(0)=-36</m>.
+			</p>
+			<p>
+				(You may leave your answer as a product of linear factors.)
+			</p>
+			<p>
+				What is the leading term of the polynomial and what is the degree of the polynomial?
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Perform the polynomial division below, and identify the quotient and remainder.
 			</p>
@@ -242,138 +220,86 @@
 				<me>%Changed the x^2 term to 10x^2 instead of 2x^2 to avoid flustering students with 4*18
 							        \left(5 x^4-3 x^3+10 x^2-1\right) \div\left(x^2+4\right)</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider two functions <m>f(x) = \sqrt{x+5}</m> and <m>g(x) = x^2 -9</m>.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Compute <m>f\cdot g(x)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Let <m>h(x) = \dfrac{f(x)}{g(x)}</m>. Compute <m>h(4)</m> and the domain of <m>h(x).</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Compute <m>f\circ g(x)</m> and find its domain.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Compute <m>f\cdot g(x)</m>.
+			</p>
+			<p>
+				Let <m>h(x) = \dfrac{f(x)}{g(x)}</m>. Compute <m>h(4)</m> and the domain of <m>h(x).</m>
+			</p>
+			<p>
+				Compute <m>f\circ g(x)</m> and find its domain.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				For each of the following functions, find the inverse function and its domain, or state that the inverse does not exist.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					<m>g(x) = \dfrac{13}{1+x}</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					<m>h(x) = x^2 - 4x</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				<m>g(x) = \dfrac{13}{1+x}</m>
+			</p>
+			<p>
+				<m>h(x) = x^2 - 4x</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				A pharmaceutical company has a process for creating a drug from bacteria. If <m>x</m> is the number of bacteria (in millions), the amount of drug (in grams) created is given by the model <me>D(x)=20x-4x^2.</me>
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					How many grams of the drug is created from 2 (million) bacteria?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What number(s) of bacteria would result in  of the drug being created?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What is the maximum amount of the drug that can be created, and how many bacteria (in millions) are required to create it?
-				</p>
-			</statement>
-		</task>
+			<p>
+				How many grams of the drug is created from 2 (million) bacteria?
+			</p>
+			<p>
+				What number(s) of bacteria would result in  of the drug being created?
+			</p>
+			<p>
+				What is the maximum amount of the drug that can be created, and how many bacteria (in millions) are required to create it?
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>f(x)=10x^3-19x^2+11x-2.</m>
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					List all possible rational roots of <m>f(x)</m> according to the rational root theorem.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					We know that <m>f(x)</m> has a root at <m>x=1</m>. Use this fact to find all the roots of <m>f(x)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Write <m>f(x)</m> as a product of linear factors.
-				</p>
-			</statement>
-		</task>
+			<p>
+				List all possible rational roots of <m>f(x)</m> according to the rational root theorem.
+			</p>
+			<p>
+				We know that <m>f(x)</m> has a root at <m>x=1</m>. Use this fact to find all the roots of <m>f(x)</m>.
+			</p>
+			<p>
+				Write <m>f(x)</m> as a product of linear factors.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				The following is a graph of the function <m>f(x)</m>.
 			</p>
 			<p>
 				The function <m>g(x)</m> is obtained from <m>f(x)</m> by: shifting <m>f(x)</m> two units to the left, stretching the function vertically by a factor of 3, and shifting 1 unit downward.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Write an algebraic expression describing how <m>g(x)</m> was obtained from <m>f(x)</m>: <me>\begin{aligned}
-											                \scalebox{1.7}{\ensuremath{\boxed{g(x) = \hspace{4cm} }}}
-											            
-											\end{aligned}</me>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Sketch <m>g(x)</m> on the graph below.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Write an algebraic expression describing how <m>g(x)</m> was obtained from <m>f(x)</m>: <me>\begin{aligned}
+										                \scalebox{1.7}{\ensuremath{\boxed{g(x) = \hspace{4cm} }}}
+										            
+										\end{aligned}</me>
+			</p>
+			<p>
+				Sketch <m>g(x)</m> on the graph below.
+			</p>
+		</statement>
 	</exercise>
 </worksheet>

--- a/source/Spring 2024/Final.ptx
+++ b/source/Spring 2024/Final.ptx
@@ -7,387 +7,325 @@
 			</p>
 	</introduction>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				What is the domain for the function <m>g(x)=\dfrac{\sqrt{x+4}}{x}</m>?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>[-4,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[4,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[-4,0)\bigcup (0,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(0,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>[-4,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>[4,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>[-4,0)\bigcup (0,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>(0,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>f(t)=e^{2t}</m> and <m>g(t)=\sqrt{t^2-1}</m>. What is <m>g\circ f(t)</m>?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>g\circ f(t)=\sqrt{t^2-1}\cdot e^{2t}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>g\circ f(t)= e^{2\sqrt{t^2-1}}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>g\circ f(t)=\sqrt{e^{2(t^2-1)}}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>g\circ f(t)=\sqrt{(e^{2t})^2-1}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>g\circ f(t)=\sqrt{t^2-1}\cdot e^{2t}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>g\circ f(t)= e^{2\sqrt{t^2-1}}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>g\circ f(t)=\sqrt{e^{2(t^2-1)}}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>g\circ f(t)=\sqrt{(e^{2t})^2-1}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								Find the end behavior of the polynomial <m>f(x)=x(x-3)^2</m>.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								Select the graph of <m>f(x)=x(x-3)^2</m>.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						Find the end behavior of the polynomial <m>f(x)=x(x-3)^2</m>.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						Select the graph of <m>f(x)=x(x-3)^2</m>.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				The line parallel to <m>y=-3x+2</m> through the point <m>(1,4)</m> is given by:
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>y=3(x-1)+4</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=-3(x-1)+4</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=-3(x+1)-4</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=\frac{1}{3}(x-1)+4</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>y=3(x-1)+4</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y=-3(x-1)+4</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y=-3(x+1)-4</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y=\frac{1}{3}(x-1)+4</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Choose the function represented by the graph, <m>y = f(x)</m>, below.
 			</p>
 			<p>
 				Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)=\left\{ \begin{matrix}
-														        (x+2)^2,&amp; x\le -2\\
-														        %-x,&amp; -1&lt;x&lt;2\\
-														        \frac{1}{2} x, &amp;x&gt; -2
-														    \end{matrix}\right.</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)=\left\{ \begin{matrix}
-														        (x+2)^2,&amp; x\le 0\\
-														        %-x,&amp; 0&lt;x&lt;-2\\
-														        \frac{1}{2} x, &amp;x&gt; 0
-														    \end{matrix}\right.</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)=\left\{ \begin{matrix}
-														        x^2,&amp; x\le -2\\
-														        %-x,&amp; 0&lt;x&lt;2\\
-														         \frac{1}{2}x, &amp;x&gt;- 2
-														    \end{matrix}\right.</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)=\left\{ \begin{matrix}
-														        (x-2)^2,&amp; x\ge -2\\
-														        %-x,&amp; -1&gt;x&gt;2\\
-														        \frac{1}{2} x, &amp;x\le- 2
-														    \end{matrix}\right.</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)=\left\{ \begin{matrix}
+												        (x+2)^2,&amp; x\le -2\\
+												        %-x,&amp; -1&lt;x&lt;2\\
+												        \frac{1}{2} x, &amp;x&gt; -2
+												    \end{matrix}\right.</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)=\left\{ \begin{matrix}
+												        (x+2)^2,&amp; x\le 0\\
+												        %-x,&amp; 0&lt;x&lt;-2\\
+												        \frac{1}{2} x, &amp;x&gt; 0
+												    \end{matrix}\right.</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)=\left\{ \begin{matrix}
+												        x^2,&amp; x\le -2\\
+												        %-x,&amp; 0&lt;x&lt;2\\
+												         \frac{1}{2}x, &amp;x&gt;- 2
+												    \end{matrix}\right.</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)=\left\{ \begin{matrix}
+												        (x-2)^2,&amp; x\ge -2\\
+												        %-x,&amp; -1&gt;x&gt;2\\
+												        \frac{1}{2} x, &amp;x\le- 2
+												    \end{matrix}\right.</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following inequalities for <m>x</m>. Write the solution in interval notation.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					<me>-3\le -4x+5</me>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					<me>|3-x|\ge 2</me>
-				</p>
-			</statement>
-		</task>
+			<p>
+				<me>-3\le -4x+5</me>
+			</p>
+			<p>
+				<me>|3-x|\ge 2</me>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following equation.
 			</p>
 			<p>
 				<me>\dfrac{5x-8}{x-1}=x</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the parabola <m>f(x)=(x-2)^2-9.</m>
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					What is the vertex of the parabola, and is it a maximum or minimum?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find <m>f(0), f(2),</m> and <m>f(5).</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find the zeros of <m>f.</m> Leave in terms of a root if necessary.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Write <m>f(x)</m> in factored form.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					For what value(s) of <m>x</m> does <m>f(x) = 2</m>? Leave in terms of a root if necessary.
-				</p>
-			</statement>
-		</task>
+			<p>
+				What is the vertex of the parabola, and is it a maximum or minimum?
+			</p>
+			<p>
+				Find <m>f(0), f(2),</m> and <m>f(5).</m>
+			</p>
+			<p>
+				Find the zeros of <m>f.</m> Leave in terms of a root if necessary.
+			</p>
+			<p>
+				Write <m>f(x)</m> in factored form.
+			</p>
+			<p>
+				For what value(s) of <m>x</m> does <m>f(x) = 2</m>? Leave in terms of a root if necessary.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the rational function <me>f(x)=\frac{x(x-1)(x-3)}{(x-3)(x+6)}</me>
 			</p>
-		</introduction>
-		<task workspace="3cm">
-			<statement>
-				<p>
-					Find the zero(s) of <m>f(x)</m>. If none exist, write “DNE".
-				</p>
-			</statement>
-		</task>
-		<task workspace="4cm">
-			<statement>
-				<p>
-					Find the vertical asymptote(s) of <m>f(x)</m>. If none exist, write “DNE".
-				</p>
-			</statement>
-		</task>
-		<task workspace="4cm">
-			<statement>
-				<p>
-					Does <m>f(x)</m> have a horizontal asymptote, slant asymptote, or neither? Circle your answer (You do not need to find the horizontal or slant asymptote, if one exists):<!-- linebreak -->
-				</p>
-			</statement>
-		</task>
-		<task workspace="4cm">
-			<statement>
-				<p>
-					Express, in interval notation, where <m>f(x)&lt;0</m>.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Find the zero(s) of <m>f(x)</m>. If none exist, write “DNE".
+			</p>
+			<p>
+				Find the vertical asymptote(s) of <m>f(x)</m>. If none exist, write “DNE".
+			</p>
+			<p>
+				Does <m>f(x)</m> have a horizontal asymptote, slant asymptote, or neither? Circle your answer (You do not need to find the horizontal or slant asymptote, if one exists):<!-- linebreak -->
+			</p>
+			<p>
+				Express, in interval notation, where <m>f(x)&lt;0</m>.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following equation for <m>x</m>:
 			</p>
-		</introduction>
-		<task workspace="4cm">
-			<statement>
-				<p>
-					<m>5\cdot4^{3x}=20</m>
-				</p>
-			</statement>
-		</task>
-		<task workspace="4cm">
-			<statement>
-				<p>
-					<m>\log(12-x)=2\log (x)</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				<m>5\cdot4^{3x}=20</m>
+			</p>
+			<p>
+				<m>\log(12-x)=2\log (x)</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Rewrite the following logarithmic expression as a single logarithm.: <me>x\log 2+3\log (y^2+1)-\log (v+w).</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Factor the following polynomial into linear factors. <me>q(x)= 2x^3-5x^2-12x</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the quotient and the remainder when you divide the function<!-- linebreak --><m>p(x)=-2x^3+5x^2+3x+4</m> by <m>D(x)=x-2</m>.
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Write the following as a single fraction in reduced form: <me>\dfrac{2x+1}{x^2-3x}-\dfrac{x}{5x-15}</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				For the following system of linear equations, determine whether or not the system has any solutions. If the system has a solution, state it as an ordered pair <m>(x,y)</m>; if the systems has infinitely many solutions, write your solutions as an ordered pair in terms of the variable <m>x</m> only. <me>\begin{aligned}
 							    \begin{cases}
@@ -396,20 +334,18 @@
 							    \end{cases}
 							\end{aligned}</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				How long will it take for an investment of $5000 to reach $10000 at an annual interest rate of 10%, compounded continuously? Leave your answer in terms of logs.
 			</p>
-		</introduction>
-		<task>
-			<hint>
-				<p>
-					<m>P(t)=P_0e^{rt}</m>
-				</p>
-			</hint>
-		</task>
+		</statement>
+		<hint>
+			<p>
+				<m>P(t)=P_0e^{rt}</m>
+			</p>
+		</hint>
 	</exercise>
 </worksheet>

--- a/source/Spring 2024/Midterm1.ptx
+++ b/source/Spring 2024/Midterm1.ptx
@@ -7,379 +7,319 @@
 			</p>
 	</introduction>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				When is a graph not the graph of a function?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								When the graph is a straight line.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								When at least one vertical line intersects the graph at more than one point.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								When the graph goes off to infinity.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								When there is at least one vertical line that does not intersect the graph.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						When the graph is a straight line.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						When at least one vertical line intersects the graph at more than one point.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						When the graph goes off to infinity.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						When there is at least one vertical line that does not intersect the graph.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Select the correct graph of <m>f(x)=\left\{\begin{matrix}
 							    x^2 &amp;,&amp; x\ge 0\\
 							    -x &amp;,&amp; x&lt;0
 							\end{matrix}\right.</m>
 			</p>
-		</introduction>
-		<task workspace="-.7cm">
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				If <m>f(x)=3x^2-\dfrac{5}{2-x}</m>, What is <m>f(-2x)</m>?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>12x^2-\dfrac{5}{2+2x}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-6x^3+\dfrac{10x}{2-x}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-6x^3-\dfrac{5}{2+2x}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-12x^2+\dfrac{5}{2-2x}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>12x^2-\dfrac{5}{2+2x}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>-6x^3+\dfrac{10x}{2-x}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>-6x^3-\dfrac{5}{2+2x}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>-12x^2+\dfrac{5}{2-2x}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Estimate the range of <m>f(x)</m> for the graph shown below:
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>[-2,2]</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[-3,5]</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[-4,5]</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[-2,5]</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>[-2,2]</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>[-3,5]</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>[-4,5]</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>[-2,5]</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following quadratic equation:<!-- linebreak --><me>x^2+4=0</me>
 			</p>
 			<p>
 				Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>x=-4</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=2</m> or <m>x=-2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=2i</m> or <m>x=-2i</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								The equation has no solution.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>x=-4</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=2</m> or <m>x=-2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=2i</m> or <m>x=-2i</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						The equation has no solution.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Factor the following quadratic. (Note: do not solve for this problem.) <me>3x^2+17x-6</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Perform the following operation and simplify. Your final answer should be written as a single fraction and contain no common factors in the numerator and denominator.
 			</p>
 			<p>
 				<me>\frac{3}{2x^2+x-6} + \frac{1}{x+2}</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Given two points <m>A(2,7)</m> and <m>B(6,5)</m>.
 			</p>
-		</introduction>
-		<task workspace="3cm">
-			<statement>
-				<p>
-					Find the midpoint of <m>A</m> and <m>B</m>.
-				</p>
-			</statement>
-		</task>
-		<task workspace="4cm">
-			<statement>
-				<p>
-					Find the slope of the line through <m>A</m> and <m>B</m>.
-				</p>
-			</statement>
-		</task>
-		<task workspace="4cm">
-			<statement>
-				<p>
-					Find the equation of the line through <m>A</m> and <m>B</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find the equation of the line through <m>(-3,1)</m> perpendicular to the line through <m>A</m> and <m>B</m>.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Find the midpoint of <m>A</m> and <m>B</m>.
+			</p>
+			<p>
+				Find the slope of the line through <m>A</m> and <m>B</m>.
+			</p>
+			<p>
+				Find the equation of the line through <m>A</m> and <m>B</m>.
+			</p>
+			<p>
+				Find the equation of the line through <m>(-3,1)</m> perpendicular to the line through <m>A</m> and <m>B</m>.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<task>
-			<statement>
-				<p>
-					Find  solutions to the equation <m>x^4-1=0</m>.<!-- linebreak -->(Hint: Let <m>y=x^2</m> and solve for <m>y</m> first).
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find all solutions to the equation <m>x^5=x</m>.<!-- linebreak -->(Hint: Can you use anything from part (a)?)
-				</p>
-			</statement>
-		</task>
+		<statement>
+			<p>
+				Find  solutions to the equation <m>x^4-1=0</m>.<!-- linebreak -->(Hint: Let <m>y=x^2</m> and solve for <m>y</m> first).
+			</p>
+			<p>
+				Find all solutions to the equation <m>x^5=x</m>.<!-- linebreak -->(Hint: Can you use anything from part (a)?)
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve for <m>x</m>: <me>3x^2 -7x-2=-2x</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve each of the following inequalities. For each part, express your answer in interval notation and then graph it on a number line.
 			</p>
-		</introduction>
-		<task workspace="5cm">
-			<statement>
-				<p>
-					<m>3\le-3x+2</m>
-				</p>
-			</statement>
-		</task>
-		<task workspace="5cm">
-			<statement>
-				<p>
-					<m>-11\le3x-5&lt;10</m>
-				</p>
-			</statement>
-		</task>
-		<task workspace="5cm">
-			<statement>
-				<p>
-					<m>-x^2\ge-7x+10</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				<m>3\le-3x+2</m>
+			</p>
+			<p>
+				<m>-11\le3x-5&lt;10</m>
+			</p>
+			<p>
+				<m>-x^2\ge-7x+10</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the possible value(s) for <m>x</m> if <me>4|x+3|-1 = 7.</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				For the function <m>f(x)=\sqrt{x^2-4}</m>, find the domain of <m>f(x)</m>. Write your answers in interval notation.
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the  for the functions below on the indicated intervals.
 			</p>
-		</introduction>
-		<task workspace="9cm">
-			<statement>
-				<p>
-					<m>f(x) = x^2+5x+8</m> on <m>[-1,3]</m>.
-				</p>
-			</statement>
-		</task>
-		<task workspace="5cm">
-			<statement>
-				<p>
-					<m>g(x) = \dfrac{6}{1+x^3}</m> on <m>[0,2]</m>.
-				</p>
-			</statement>
-		</task>
+			<p>
+				<m>f(x) = x^2+5x+8</m> on <m>[-1,3]</m>.
+			</p>
+			<p>
+				<m>g(x) = \dfrac{6}{1+x^3}</m> on <m>[0,2]</m>.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following equations.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					<m>\dfrac{1-x}{x+2}=-3</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					<m>\sqrt{6-x}=-x</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				<m>\dfrac{1-x}{x+2}=-3</m>
+			</p>
+			<p>
+				<m>\sqrt{6-x}=-x</m>
+			</p>
+		</statement>
 	</exercise>
 </worksheet>

--- a/source/Spring 2024/Midterm2.ptx
+++ b/source/Spring 2024/Midterm2.ptx
@@ -7,382 +7,320 @@
 			</p>
 	</introduction>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				A parabola has a vertex of <m>(-3,2)</m>, and the vertex is a maximum. What is a possible equation for the parabola?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>y=(x+3)^2+2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=-(x-3)^2-2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=-(x+3)^2+2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=-(x-2)^2-3</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>y=(x+3)^2+2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y=-(x-3)^2-2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y=-(x+3)^2+2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y=-(x-2)^2-3</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				The graph below has which properties?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								The graph is a function and does have an inverse.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								The graph is neither a function nor has an inverse.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								The graph is not a function, but does have an inverse.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								The graph is a function, but does not have an inverse.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						The graph is a function and does have an inverse.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						The graph is neither a function nor has an inverse.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						The graph is not a function, but does have an inverse.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						The graph is a function, but does not have an inverse.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider a polynomial <me>P(x) = ax^n</me> You know <m>n</m> is a positive integer, but do not know <m>a</m>. If as <m>x\to-\infty</m> <m>P(x)\to-\infty</m> and as <m>x\to+\infty</m> <m>P(x)\to-\infty</m>. What do you know about <m>a</m> and <m>n</m>?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>a</m> is positive and <m>n</m> is odd.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>a</m> is negative and <m>n</m> is odd.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>a</m> is negative and <m>n</m> is even.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>a</m> is positive and <m>n</m> is even.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>a</m> is positive and <m>n</m> is odd.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>a</m> is negative and <m>n</m> is odd.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>a</m> is negative and <m>n</m> is even.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>a</m> is positive and <m>n</m> is even.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				A graph of a generic quadratic <m>y=ax^2+bx+c</m>, with <m>a\neq0</m>
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								will always touch (intersect) the <m>x</m>-axis in 2 different places.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								will always touch (intersect) the <m>x</m>-axis at least once.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								will always touch (intersect) the <m>x</m>-axis exactly once.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								may not touch (intersect) the <m>x</m>-axis at all.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						will always touch (intersect) the <m>x</m>-axis in 2 different places.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						will always touch (intersect) the <m>x</m>-axis at least once.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						will always touch (intersect) the <m>x</m>-axis exactly once.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						may not touch (intersect) the <m>x</m>-axis at all.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				A graph of a generic quadratic <m>y=ax^2+bx+c</m>, with <m>a\neq0</m>
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								will always touch (intersect) the <m>y</m>-axis in 2 different places.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								will always touch (intersect) the <m>y</m>-axis at least once.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								will always touch (intersect) the <m>y</m>-axis exactly once.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								may not touch (intersect) the <m>y</m>-axis at all.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						will always touch (intersect) the <m>y</m>-axis in 2 different places.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						will always touch (intersect) the <m>y</m>-axis at least once.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						will always touch (intersect) the <m>y</m>-axis exactly once.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						may not touch (intersect) the <m>y</m>-axis at all.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Ed wants to build a rectangular pen for his sheep, and he wants to make the pen have the largest possible area. Ed has 40 feet worth of fencing available.
 			</p>
-		</introduction>
-		<task workspace="8cm">
-			<statement>
-				<p>
-					Let <m>x</m> denote the length of the horizontal side. Express the area <m>A</m> in terms of <m>x</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Using the expression obtained in (a), find the value of <m>x</m> that maximizes <m>A</m>, the area of the pen, and find this maximal area.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Let <m>x</m> denote the length of the horizontal side. Express the area <m>A</m> in terms of <m>x</m>.
+			</p>
+			<p>
+				Using the expression obtained in (a), find the value of <m>x</m> that maximizes <m>A</m>, the area of the pen, and find this maximal area.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the quotient and remainder of the following: <me>(8x^4+2x^3-10x^2+4)\div (2x^2-1)</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				The graph of a function <m>y = f(x)</m> is displayed below:
 			</p>
 			<p>
 				Draw the graph of <m>y = -f(2x) - 1</m> below.
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>f(x)=\dfrac{x+5}{2x-3}</m>.
 			</p>
-		</introduction>
-		<task workspace="8cm">
-			<statement>
-				<p>
-					Find the domain of <m>f</m>.
-				</p>
-			</statement>
-		</task>
-		<task workspace="8cm">
-			<statement>
-				<p>
-					Find <m>f^{-1}(x)</m>.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Find the domain of <m>f</m>.
+			</p>
+			<p>
+				Find <m>f^{-1}(x)</m>.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				A box maker can produce 100 boxes every 4 hours. They start one morning with 75 boxes already made.
 			</p>
-		</introduction>
-		<task workspace="5cm">
-			<statement>
-				<p>
-					What is the hourly rate of production (with correct units)?
-				</p>
-			</statement>
-		</task>
-		<task workspace="6cm">
-			<statement>
-				<p>
-					Write the equation for the number of boxes after <m>x</m> hours that day?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					How many hours have to pass before they have 300 boxes that day?
-				</p>
-			</statement>
-		</task>
+			<p>
+				What is the hourly rate of production (with correct units)?
+			</p>
+			<p>
+				Write the equation for the number of boxes after <m>x</m> hours that day?
+			</p>
+			<p>
+				How many hours have to pass before they have 300 boxes that day?
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>f(x)=2(x+2)(x-2)(x-5)^2</m> be a polynomial function.
 			</p>
-		</introduction>
-		<task workspace=".5cm">
-			<statement>
-				<p>
-					Fill in the blanks with the end behavior of <m>f(x)</m> (no justification needed):
-				</p>
-				<p>
-					As <m>x\to -\infty</m>, <m>y\to</m> .
-				</p>
-				<p>
-					As <m>x\to +\infty</m>, <m>y\to</m> .
-				</p>
-			</statement>
-		</task>
-		<task workspace="0.5in">
-			<statement>
-				<p>
-					Write the <m>x</m>-intercepts (zeros) of the function <m>f(x)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Using your answers to parts (a) and (b), sketch the graph of <m>f(x)</m> on the <m>xy</m>-plane provided below. Clearly indicate the <m>x</m>-intercepts of <m>f(x)</m>.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Fill in the blanks with the end behavior of <m>f(x)</m> (no justification needed):
+			</p>
+			<p>
+				As <m>x\to -\infty</m>, <m>y\to</m> .
+			</p>
+			<p>
+				As <m>x\to +\infty</m>, <m>y\to</m> .
+			</p>
+			<p>
+				Write the <m>x</m>-intercepts (zeros) of the function <m>f(x)</m>.
+			</p>
+			<p>
+				Using your answers to parts (a) and (b), sketch the graph of <m>f(x)</m> on the <m>xy</m>-plane provided below. Clearly indicate the <m>x</m>-intercepts of <m>f(x)</m>.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>f(x) = 2x^{3}-x^{2}-7x+6</m>.
 			</p>
-		</introduction>
-		<task workspace="3cm">
-			<statement>
-				<p>
-					What are all the possible rational roots of <m>f(x)</m> according to the rational root theorem?
-				</p>
-			</statement>
-		</task>
-		<task workspace="12cm">
-			<statement>
-				<p>
-					If we know that <m>f(x)</m> has a root at <m>x=1</m>, find all the roots of <m>f(x)</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Write <m>f(x)</m> as a product of linear factors.
-				</p>
-			</statement>
-		</task>
+			<p>
+				What are all the possible rational roots of <m>f(x)</m> according to the rational root theorem?
+			</p>
+			<p>
+				If we know that <m>f(x)</m> has a root at <m>x=1</m>, find all the roots of <m>f(x)</m>
+			</p>
+			<p>
+				Write <m>f(x)</m> as a product of linear factors.
+			</p>
+		</statement>
 	</exercise>
 </worksheet>

--- a/source/Spring 2025/Final.ptx
+++ b/source/Spring 2025/Final.ptx
@@ -6,298 +6,288 @@
 				Multiple choice section. All points are for choosing the correct answer. No justification is needed.
 			</p>
 	</introduction>
-        <exercise>
-                <statement>
-                        <p>
-                                Starting form the base function <m>|x|</m> (graph shown below).
-                        </p>
-                        <p>
-                                Select the function graphed below.
-                        </p>
-                </statement>
-                <choices multiple-correct="no">
-                        <choice>
-                                <statement>
-                                        <p>
-                                                <m>f(x)=2|x-1|+2</m>
-                                        </p>
-                                </statement>
-                        </choice>
-                        <choice>
-                                <statement>
-                                        <p>
-                                                <m>f(x)=2|x+1|+2</m>
-                                        </p>
-                                </statement>
-                        </choice>
-                        <choice>
-                                <statement>
-                                        <p>
-                                                <m>f(x)=\frac{1}{2}|x-1|+2</m>
-                                        </p>
-                                </statement>
-                        </choice>
-                        <choice>
-                                <statement>
-                                        <p>
-                                                <m>f(x)=\frac{1}{2}|x+1|+2</m>
-                                        </p>
-                                </statement>
-                        </choice>
-                        <choice>
-                                <statement>
-                                        <p>
-                                                None of the above.
-                                        </p>
-                                </statement>
-                        </choice>
-                </choices>
-        </exercise>
 	<exercise>
-		<introduction>
+		<statement>
+			<p>
+				Starting form the base function <m>|x|</m> (graph shown below).
+			</p>
+			<p>
+				Select the function graphed below.
+			</p>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						A. <m>f(x)=2|x-1|+2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						B. <m>f(x)=2|x+1|+2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						C. <m>f(x)=\frac{1}{2}|x-1|+2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						D. <m>f(x)=\frac{1}{2}|x+1|+2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						E. None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
+	</exercise>
+	<exercise>
+		<statement>
 			<p>
 				Which of the following is a polynomial, <m>p(x)</m> with roots of <m>-3</m>, <m>\sqrt{2}</m>, and 1.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>p(x)=(x-3)(x+2)^2(x+1)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>p(x)=(x+3)(x-2)^2(x-1)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>p(x)=(x-3)(x+\sqrt{2})(x+1)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>p(x)=(x+3)(x-\sqrt{2})(x-1)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>p(x)=(x-3)(x+2)^2(x+1)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>p(x)=(x+3)(x-2)^2(x-1)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>p(x)=(x-3)(x+\sqrt{2})(x+1)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>p(x)=(x+3)(x-\sqrt{2})(x-1)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the parabola <m>f(x)=(x+3)^2+k</m>. What is <m>k</m> if <m>f(x)</m> has only one zero?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>k=0</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>k&gt;0</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>k=-9</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>k=-3</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>k=0</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>k&gt;0</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>k=-9</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>k=-3</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the rational function <me>f(x)=\dfrac{x^3+5x+3}{2x^2+1}</me> What can we say about any asymptotes for this function?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)</m> has a horizontal asymptote at <m>y=0</m>.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)</m> has a horizontal asymptote at <m>y=\dfrac{1}{2}</m>.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								We cannot say anything about asymptotes of <m>f(x)</m>.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>f(x)</m> has a slant asymptote.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)</m> has a horizontal asymptote at <m>y=0</m>.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)</m> has a horizontal asymptote at <m>y=\dfrac{1}{2}</m>.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						We cannot say anything about asymptotes of <m>f(x)</m>.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>f(x)</m> has a slant asymptote.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>f(x)=x^2-\sqrt{x+1}</m> and <m>g(x)=\dfrac{-3}{2x}</m>, what is <m>f(g(x))</m>?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>\dfrac{-3x}{2}+\dfrac{3\sqrt{x+1}}{2x}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>\dfrac{9}{4x^2}-\sqrt{\frac{-3}{2x}+1}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>\dfrac{-9}{4x^2}-\sqrt{\frac{-3}{2x}+1}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>\dfrac{-3}{2x^2-2\sqrt{x+1}}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>\dfrac{-3x}{2}+\dfrac{3\sqrt{x+1}}{2x}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>\dfrac{9}{4x^2}-\sqrt{\frac{-3}{2x}+1}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>\dfrac{-9}{4x^2}-\sqrt{\frac{-3}{2x}+1}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>\dfrac{-3}{2x^2-2\sqrt{x+1}}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				What is the domain of the following function: <me>f(x)=\dfrac{\sqrt{x+3}}{x-5}</me>
 			</p>
 			<p>
 				Free answer section. <term>Work must be shown to get credit for any answer.</term> Partial credit may be given even for incorrect final answers, so show your work.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>[-3,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty,5)\bigcup(5,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[-3,5)\bigcup(5,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>[-3,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>(-\infty,5)\bigcup(5,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>[-3,5)\bigcup(5,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>(-\infty,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following inequality and write your answers in interval notation. <me>|7x + 3| + 8 \geq 13\,</me>
 			</p>
 			<p>
 				<m>\mbox{Interval(s)}: \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Combine the following into a single fraction with no common factors on the top and bottom.
 			</p>
@@ -307,100 +297,86 @@
 			<p>
 				<m>\mbox{$f(x)=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{\dfrac{a}{b}}{b}} \hspace{5cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								Write the function <m>f(x)=2x^{2}+4x+7</m> in vertex form, <m>a(x-h)^2+k</m>.
-							</p>
-							<p>
-								<m>\mbox{$f(x)=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								What are the coordinates of the vertex?
-							</p>
-							<p>
-								<m>\mbox{Vertex: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{4cm} }}}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								Is the vertex a maximum or a minimum?
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						Write the function <m>f(x)=2x^{2}+4x+7</m> in vertex form, <m>a(x-h)^2+k</m>.
+					</p>
+					<p>
+						<m>\mbox{$f(x)=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						What are the coordinates of the vertex?
+					</p>
+					<p>
+						<m>\mbox{Vertex: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{4cm} }}}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						Is the vertex a maximum or a minimum?
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Write the following as a single log. <me>f(x)=4\ln(x+2)-\frac{1}{2}\ln z+y\ln 3</me>
 			</p>
 			<p>
 				<m>\mbox{$f(x)=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{\dfrac{a}{b}}{b}} \hspace{5cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the rational function <me>f(x)=\dfrac{x-5}{x^2+2x}</me>
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Find the zero(s) of <m>f</m>
-				</p>
-				<p>
-					<m>\mbox{$x=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find the vertical asymptote(s) of <m>f</m>
-				</p>
-				<p>
-					<m>\mbox{$x=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					For what intervals of <m>x</m> is <m>f(x)\le 0</m>
-				</p>
-				<p>
-					<m>\mbox{Interval(s)}: \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				Find the zero(s) of <m>f</m>
+			</p>
+			<p>
+				<m>\mbox{$x=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+			</p>
+			<p>
+				Find the vertical asymptote(s) of <m>f</m>
+			</p>
+			<p>
+				<m>\mbox{$x=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+			</p>
+			<p>
+				For what intervals of <m>x</m> is <m>f(x)\le 0</m>
+			</p>
+			<p>
+				<m>\mbox{Interval(s)}: \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the inverse function for the function below: <me>f(x)=\dfrac{2x}{5-3x}</me>
 			</p>
 			<p>
 				<m>\mbox{$f^{-1}(x)=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{\dfrac{a}{b}}{b}} \hspace{5cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the following equation for <m>x:</m> <me>\begin{aligned}
 							        \log_{6}(x)+\log_6 (x-1) = 1
@@ -410,10 +386,10 @@
 			<p>
 				<m>\mbox{$x$ = } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				For what value(s) of <m>x</m> does <me>\begin{aligned}
 							        \left(\ln(x)\right)^2 - 3\ln(x)=0\,?
@@ -423,58 +399,56 @@
 			<p>
 				<m>\mbox{$x$ = } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				A swimming pool is being emptied, and the amount of water (in liters) in the pool at time <m>t</m> (in minutes) is given by <me>P(t) = P_0 \cdot 5^{rt}</me> where <m>P_0</m> and <m>r</m> are some constants. If there is initially <m>1000</m> liters of water in the pool, and after <m>7</m> minutes there is <m>500</m> liters of water in the pool, find the values of <m>P_0</m> and <m>r</m>.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								What is <m>P_0</m>?
-							</p>
-							<p>
-								<m>\mbox{$P_0$ = } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								What is <m>r</m>? (Leave the value for <m>r</m> in terms of a logarithm.)
-							</p>
-							<p>
-								<m>\mbox{$r$ = } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								Knowing that the pool is being emptied, is <m>r</m> positive or negative?
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						What is <m>P_0</m>?
+					</p>
+					<p>
+						<m>\mbox{$P_0$ = } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						What is <m>r</m>? (Leave the value for <m>r</m> in terms of a logarithm.)
+					</p>
+					<p>
+						<m>\mbox{$r$ = } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						Knowing that the pool is being emptied, is <m>r</m> positive or negative?
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider the following polynomial <me>q(x)= 3x^3+16x^2+3x-10</me> Suppose we know <m>q(x)</m> has a root <m>x=-1</m>, write <m>q(x)</m> as a product of linear factors.
 			</p>
 			<p>
 				<m>\mbox{$q(x)$ = } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				For the following system of linear equations, determine whether or not the system has any solutions. If the system has a solution, state it as an ordered pair <m>(x,y)</m>; if the systems has infinitely many solutions, write your solutions as an ordered pair in terms of the variable <m>x</m> only. <me>\begin{cases}
 							4 x  +  3 y &amp; = 7 \\
@@ -484,6 +458,6 @@
 			<p>
 				<m>(x,y) = \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 </worksheet>

--- a/source/Spring 2025/Midterm1.ptx
+++ b/source/Spring 2025/Midterm1.ptx
@@ -7,390 +7,340 @@
 			</p>
 	</introduction>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				<term>Select ALL</term> of the following that are functions:
 			</p>
-		</introduction>
-		<task workspace="-.7cm">
-				<choices multiple-correct="yes">
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="yes">
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the solution to the following inequality <me>|x-3|\ge-3</me>
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty,0]\cup[6,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								There is no <m>x</m> that solves the inequality.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[0,6]</m>
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>(-\infty,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>(-\infty,0]\cup[6,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						There is no <m>x</m> that solves the inequality.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>[0,6]</m>
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				<term>Select ALL</term> (real and complex) solutions to the equation: <me>x^3=-x</me>
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="yes">
-					<choice>
-						<statement>
-							<p>
-								<m>x=0</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=-1</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=i</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>x=-i</m>
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="yes">
+			<choice>
+				<statement>
+					<p>
+						<m>x=0</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=-1</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=i</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>x=-i</m>
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Select the correct graph of <m>f(x)=\left\{\begin{matrix}
 							    x^2 &amp;,&amp; x\ge 0\\
 							    -x &amp;,&amp; x&lt;0
 							\end{matrix}\right.</m>
 			</p>
-		</introduction>
-		<task workspace="-.7cm">
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				If <m>f(x)=5x^2-\dfrac{1}{3-x}</m>, What is <m>f(-2z)</m>?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>20z^2-\dfrac{1}{3+2z}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-10z^3+\dfrac{2z}{3-z}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-10z^3-\dfrac{2z}{3+2z}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>-20z^2+\dfrac{1}{3-2z}</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>20z^2-\dfrac{1}{3+2z}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>-10z^3+\dfrac{2z}{3-z}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>-10z^3-\dfrac{2z}{3+2z}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>-20z^2+\dfrac{1}{3-2z}</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the domain of the function: <me>\dfrac{\sqrt{x+3}}{x-7}</me>
 			</p>
 			<p>
 				Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty, -3)\bigcup(-3,7)\bigcup(7,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>(-\infty, 7)\bigcup(7,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[-3,7)\bigcup(7,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>[-3,\infty)</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the Above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>(-\infty, -3)\bigcup(-3,7)\bigcup(7,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>(-\infty, 7)\bigcup(7,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>[-3,7)\bigcup(7,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>[-3,\infty)</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the Above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Given the graph of the function <m>y=F(x)</m> describing the temperature of lake Mendota over one year below:
 			</p>
-		</introduction>
-		<task workspace="2cm">
-			<statement>
-				<p>
-					Find the day(s) and temperature Lake Mendota reached a local maximum temperature.
-				</p>
-			</statement>
-		</task>
-		<task workspace="2cm">
-			<statement>
-				<p>
-					Find the day(s) and temperature(s) Lake Mendota reached a local minimum temperature.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Find the day(s) and temperature Lake Mendota reached a local maximum temperature.
+			</p>
+			<p>
+				Find the day(s) and temperature(s) Lake Mendota reached a local minimum temperature.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Given two points <m>A\left(\dfrac{1}{2},\dfrac{1}{2}\right)</m> and <m>B(0,-1)</m>. Find the equation of the line through <m>A</m> and <m>B</m>, write it in the point-slope form.
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Given the line <m>y=\dfrac{2}{3}x-4</m>:
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Find the equation of the line through <m>(-3,1)</m> parallel to the line.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Find the equation of the line through the point <m>(-3,1)</m> perpendicular to the line.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Find the equation of the line through <m>(-3,1)</m> parallel to the line.
+			</p>
+			<p>
+				Find the equation of the line through the point <m>(-3,1)</m> perpendicular to the line.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Write the following as a single fraction. (In your final answer, make sure that the numerator and the denominator do not contain a common factor other than 1.)
 			</p>
 			<p>
 				<m>\displaystyle{\frac{x+2}{x^2+5x+4} + \frac{x+1}{2x+8}}</m>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve each of the following inequalities. For each part, express your answer in interval notation.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					<m>8 &lt; 9+4x \leq 11</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					<m>3x^2 \geq 13x-4</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				<m>8 &lt; 9+4x \leq 11</m>
+			</p>
+			<p>
+				<m>3x^2 \geq 13x-4</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the given equation: <me>(x+2)(x+3)=12x-6</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the given equation: <me>2x^2 -6x+1=0</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the possible value(s) for <m>x</m> if <me>2|x-5|+4 = 7.</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Find the values of <m>x</m> that solve the following equation: <me>(3-2x)^2-(3-2x)-2=0</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				The function graphed below represents the <term>Percentage of Children Under 5 with Acute Malnutrition (Wasting)</term> in a small occupied territory.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					What was the average rate of change of wasting between 2000 and 2020?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What was the average rate of change of wasting between 2020 and 2024?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					For what period of time (intervals) is the function <term>increasing</term>? Express your answer in interval notation.
-				</p>
-			</statement>
-		</task>
+			<p>
+				What was the average rate of change of wasting between 2000 and 2020?
+			</p>
+			<p>
+				What was the average rate of change of wasting between 2020 and 2024?
+			</p>
+			<p>
+				For what period of time (intervals) is the function <term>increasing</term>? Express your answer in interval notation.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Solve the given equation:  <me>\sqrt{x+7}-x+4=5</me>
 			</p>
-		</introduction>
-		<task>
-			<hint>
-				<p>
-					check your solutions.
-				</p>
-			</hint>
-		</task>
+		</statement>
+		<hint>
+			<p>
+				check your solutions.
+			</p>
+		</hint>
 	</exercise>
 </worksheet>

--- a/source/Spring 2025/Midterm2.ptx
+++ b/source/Spring 2025/Midterm2.ptx
@@ -7,145 +7,139 @@
 			</p>
 	</introduction>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				A parabola has a vertex of <m>(5,-2)</m>, and the vertex is a maximum. What is a possible equation for the parabola?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>y=(x+5)^2-2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=-(x-5)^2+2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=-(x-5)^2-2</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>y=-(x-2)^2+5</m>
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>y=(x+5)^2-2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y=-(x-5)^2+2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y=-(x-5)^2-2</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>y=-(x-2)^2+5</m>
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				The graph below has which properties?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								The graph  a function and  have an inverse.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								The graph is  a function does  have an inverse.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								The graph is  a function, but  have an inverse.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								The graph  a function, but does  have an inverse.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						The graph  a function and  have an inverse.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						The graph is  a function does  have an inverse.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						The graph is  a function, but  have an inverse.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						The graph  a function, but does  have an inverse.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Consider a polynomial <me>P(x) = ax^n</me> You know <m>n</m> is a positive integer, but do not know <m>a</m>. If as <m>x\to-\infty</m> <m>P(x)\to+\infty</m> and as <m>x\to+\infty</m> <m>P(x)\to-\infty</m>. What do you know about <m>a</m> and <m>n</m>?
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-							<p>
-								<m>a</m> is positive and <m>n</m> is odd.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>a</m> is negative and <m>n</m> is odd.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>a</m> is negative and <m>n</m> is even.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								<m>a</m> is positive and <m>n</m> is even.
-							</p>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+					<p>
+						<m>a</m> is positive and <m>n</m> is odd.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>a</m> is negative and <m>n</m> is odd.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>a</m> is negative and <m>n</m> is even.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						<m>a</m> is positive and <m>n</m> is even.
+					</p>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Here is a graph of the parent function <m>f(x)= \sqrt{x}</m>.
 			</p>
@@ -164,258 +158,178 @@
 			<p>
 				<m>\boxed{\phantom{\dfrac{aaa}{b}}}</m> = <m>\displaystyle \frac{3}{2}\sqrt{-x+1}-1</m>
 			</p>
-		</introduction>
-		<task>
-		</task>
-		<task>
-		</task>
-		<task>
-		</task>
-		<task>
-		</task>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Select the graph of <m>f(x)=x^2(x-2)^2</m>.
 			</p>
 			<p>
 				Free answer section. Work must be shown to get credit for any answer. Partial credit may be given even for incorrect final answers, so show your work.
 			</p>
-		</introduction>
-		<task>
-				<choices multiple-correct="no">
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-						</statement>
-					</choice>
-					<choice>
-						<statement>
-							<p>
-								None of the above.
-							</p>
-						</statement>
-					</choice>
-				</choices>
-		</task>
+		</statement>
+		<choices multiple-correct="no">
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+				</statement>
+			</choice>
+			<choice>
+				<statement>
+					<p>
+						None of the above.
+					</p>
+				</statement>
+			</choice>
+		</choices>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Every <m>3</m> years, an average family in the US generates <m>10</m> tons of trash. Your family created <m>95</m> tons of waste before you were born. Let <m>x</m> represent years after your birth.
 			</p>
-		</introduction>
-		<task workspace="-.7cm">
-			<statement>
-				<p>
-					Find a linear function <m>w=f(x)</m> that determines the total amount of waste created by an average family <m>w</m> as a function of time <m>x</m>.
-				</p>
-			</statement>
-		</task>
-		<task workspace="-.7cm">
-			<statement>
-				<p>
-					Find <m>f(21)</m> and explain what it tells you in this situation.
-				</p>
-			</statement>
-		</task>
-		<task workspace="-.7cm">
-			<statement>
-				<p>
-					Find <m>x=f^{-1}(w)</m> for value of <m>w</m>.
-				</p>
-			</statement>
-		</task>
-		<task workspace="-.7cm">
-			<statement>
-				<p>
-					Find <m>f^{-1}(205)</m> and explain what it tells you in this situation.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Find a linear function <m>w=f(x)</m> that determines the total amount of waste created by an average family <m>w</m> as a function of time <m>x</m>.
+			</p>
+			<p>
+				Find <m>f(21)</m> and explain what it tells you in this situation.
+			</p>
+			<p>
+				Find <m>x=f^{-1}(w)</m> for value of <m>w</m>.
+			</p>
+			<p>
+				Find <m>f^{-1}(205)</m> and explain what it tells you in this situation.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Perform the polynomial long division, then identify the quotient and the remainder. <me>\left(x^4+3 x^3+5x^2+2x+1\right) \div\left(x^2+1\right)</me>
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Suppose a ball is thrown directly upward, and its height (in feet) after <m>t</m> seconds is given by <me>y(t) = - 16 t^2 + 16t + a\,, \quad (\mathrm{ft})</me> with <m>a</m> to be determined.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					If at time <m>t=0</m>, the ball is thrown at height <m>10 \mathrm{ft}</m>, what is the value of <m>a</m>?
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Write the function <m>y(t)</m> in vertex form by completing the square.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					When does the ball reach its maximum height? What is the maximum height? Please include units for both answers.
-				</p>
-				<p>
-					<m>\mbox{Max Height: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
-				</p>
-				<p>
-					<m>\mbox{Time: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				If at time <m>t=0</m>, the ball is thrown at height <m>10 \mathrm{ft}</m>, what is the value of <m>a</m>?
+			</p>
+			<p>
+				Write the function <m>y(t)</m> in vertex form by completing the square.
+			</p>
+			<p>
+				When does the ball reach its maximum height? What is the maximum height? Please include units for both answers.
+			</p>
+			<p>
+				<m>\mbox{Max Height: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+			</p>
+			<p>
+				<m>\mbox{Time: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<task>
-			<statement>
-				<p>
-					Find the polynomial <m>h(x)</m> of least possible degree with  that has a repeated root of <m>-3</m> with multiplicity 2 and a root of <m>\sqrt{5}</m> such that <m>h(0)=90</m>.
-				</p>
-				<p>
-					(You may leave your answer as a product of linear factors.)
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What is the leading term of the polynomial and what is the degree of the polynomial?
-				</p>
-				<p>
-					<m>\mbox{Leading term: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
-				</p>
-				<p>
-					<m>\mbox{Degree: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
-				</p>
-			</statement>
-		</task>
+		<statement>
+			<p>
+				Find the polynomial <m>h(x)</m> of least possible degree with  that has a repeated root of <m>-3</m> with multiplicity 2 and a root of <m>\sqrt{5}</m> such that <m>h(0)=90</m>.
+			</p>
+			<p>
+				(You may leave your answer as a product of linear factors.)
+			</p>
+			<p>
+				What is the leading term of the polynomial and what is the degree of the polynomial?
+			</p>
+			<p>
+				<m>\mbox{Leading term: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+			</p>
+			<p>
+				<m>\mbox{Degree: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Compute the following.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					Let <m>f(x) = \dfrac{1}{2-x}</m> and <m>g(x) = \sqrt{x+12}.</m> Let <m>h(x) = \dfrac{f(x)}{g(x)}.</m> Compute <m>h(4).</m>
-				</p>
-			</statement>
-		</task>
-		<task workspace="1cm">
-			<statement>
-				<p>
-					Let <m>p(x) = \sqrt{-x + 6}</m> and <m>q(x) = \sqrt{x-1}</m>. Let <m>r(x) = p\cdot q(x)</m>. Find the domain of <m>r(x)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Let <m>a(x) = \dfrac{1}{5-x}</m> and <m>b(x) = x^2+1</m>. Compute <m>a \circ b(x)</m> and find its domain.
-				</p>
-			</statement>
-		</task>
+			<p>
+				Let <m>f(x) = \dfrac{1}{2-x}</m> and <m>g(x) = \sqrt{x+12}.</m> Let <m>h(x) = \dfrac{f(x)}{g(x)}.</m> Compute <m>h(4).</m>
+			</p>
+			<p>
+				Let <m>p(x) = \sqrt{-x + 6}</m> and <m>q(x) = \sqrt{x-1}</m>. Let <m>r(x) = p\cdot q(x)</m>. Find the domain of <m>r(x)</m>.
+			</p>
+			<p>
+				Let <m>a(x) = \dfrac{1}{5-x}</m> and <m>b(x) = x^2+1</m>. Compute <m>a \circ b(x)</m> and find its domain.
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>f(x)=\dfrac{3}{x+4}</m>. Find <m>f^{-1}(x)</m>, and find the domain of <m>f(x)</m>.
 			</p>
-		</introduction>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>g(x)=\sqrt{x+4}+1</m>. The graph is shown below.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					What is the domain and range of <m>g(x)</m>? (Write in interval notation.)
-				</p>
-				<p>
-					<m>\mbox{Domain: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
-				</p>
-				<p>
-					<m>\mbox{Range: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What is <m>g^{-1}(x)</m>? <m>g^{-1}(x) = \scalebox{1.2}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					What are the domain and range of <m>g^{-1}(x)</m>?
-				</p>
-				<p>
-					<m>\mbox{Domain: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
-				</p>
-				<p>
-					<m>\mbox{Range: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				What is the domain and range of <m>g(x)</m>? (Write in interval notation.)
+			</p>
+			<p>
+				<m>\mbox{Domain: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+			</p>
+			<p>
+				<m>\mbox{Range: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+			</p>
+			<p>
+				What is <m>g^{-1}(x)</m>? <m>g^{-1}(x) = \scalebox{1.2}{\ensuremath{\boxed{ \phantom{\dfrac{a}{b}} \hspace{5cm} }}}</m>
+			</p>
+			<p>
+				What are the domain and range of <m>g^{-1}(x)</m>?
+			</p>
+			<p>
+				<m>\mbox{Domain: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+			</p>
+			<p>
+				<m>\mbox{Range: } \scalebox{1.1}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{3cm} }}}</m>
+			</p>
+		</statement>
 	</exercise>
 	<exercise>
-		<introduction>
+		<statement>
 			<p>
 				Let <m>f(x)= 3 x^3 - 13 x^2 - 11 x + 5</m>.
 			</p>
-		</introduction>
-		<task>
-			<statement>
-				<p>
-					List all possible rational roots of <m>f(x)</m> according to the rational root theorem.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					We know that <m>f(x)</m> has a root at <m>x=5</m>. Use this fact to find all the roots of <m>f(x)</m>.
-				</p>
-			</statement>
-		</task>
-		<task>
-			<statement>
-				<p>
-					Write <m>f(x)</m> as a product of linear factors.
-				</p>
-				<p>
-					<m>\mbox{$f(x)=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{8cm} }}}</m>
-				</p>
-			</statement>
-		</task>
+			<p>
+				List all possible rational roots of <m>f(x)</m> according to the rational root theorem.
+			</p>
+			<p>
+				We know that <m>f(x)</m> has a root at <m>x=5</m>. Use this fact to find all the roots of <m>f(x)</m>.
+			</p>
+			<p>
+				Write <m>f(x)</m> as a product of linear factors.
+			</p>
+			<p>
+				<m>\mbox{$f(x)=$ } \scalebox{1.5}{\ensuremath{\boxed{ \phantom{\frac{a}{b}} \hspace{8cm} }}}</m>
+			</p>
+		</statement>
 	</exercise>
 </worksheet>


### PR DESCRIPTION
## Summary
- update the custom PreTeXT writer to collapse exercise introductions and tasks into a single statement and hoist choices to the exercise level
- regenerate the .ptx sources with the new writer output

## Testing
- find source -name '*.tex' -print0 | while IFS= read -r -d '' f; do out="${f%.tex}.ptx"; pandoc "$f" -t pretext.lua -o "$out"; done

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d880d12548328b86d68d1a39af00e)